### PR TITLE
add vercel config to silence gh notifs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "trailingSlash": false,
+  "github": { "silent": true }
+}


### PR DESCRIPTION
The comments from the vercel bot are noisy. We do this silencing for the garage and animation url: https://vercel.com/guides/how-to-prevent-vercel-github-comments