### PR TITLE
Use react cache for db queries

### DIFF
--- a/components/new-project-dialog.tsx
+++ b/components/new-project-dialog.tsx
@@ -38,10 +38,11 @@ export default function NewProjectDialog({ team, children, ...props }: Props) {
         newProjectName,
         newProjectDescription
       );
-      router.push(`/${team.slug}/${res.slug}`);
-      router.refresh();
+      props.onOpenChange && props.onOpenChange(false);
       setNewProjectName("");
       setNewProjectDescription("");
+      router.push(`/${team.slug}/${res.slug}`);
+      router.refresh();
     });
   };
 

--- a/db/api/auth.ts
+++ b/db/api/auth.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from "crypto";
 import { eq } from "drizzle-orm";
 import { sealData, unsealData } from "iron-session";
+import { cache } from "react";
 import { db, slugify, tbl, teamMemberships, teams, users } from "./db";
 
-export async function createUserAndPersonalTeam(
+export const createUserAndPersonalTeam = cache(async function (
   address: string,
   teamName: string,
   email?: string
@@ -40,9 +41,11 @@ export async function createUserAndPersonalTeam(
     throw new Error("Failed to create user and personal team.");
   }
   return info;
-}
+});
 
-export async function userAndPersonalTeamByAddress(address: string) {
+export const userAndPersonalTeamByAddress = cache(async function (
+  address: string
+) {
   const res = await db
     .select({
       user: users,
@@ -66,4 +69,4 @@ export async function userAndPersonalTeamByAddress(address: string) {
     },
     personalTeam: res.personalTeam,
   };
-}
+});

--- a/db/api/projects.ts
+++ b/db/api/projects.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from "crypto";
 import { and, eq } from "drizzle-orm";
+import { cache } from "react";
 import { Project } from "../schema";
 import { db, projects, slugify, tbl, teamProjects, teams } from "./db";
 
-export async function createProject(
+export const createProject = cache(async function (
   teamId: string,
   name: string,
   description: string | null
@@ -24,9 +25,9 @@ export async function createProject(
   ]);
   const project: Project = { id: projectId, name, description, slug };
   return project;
-}
+});
 
-export async function projectsByTeamId(teamId: string) {
+export const projectsByTeamId = cache(async function (teamId: string) {
   const res = await db
     .select({ projects }) // TODO: Figure out why if we don't specify select key, projects key ends up as actual table name.
     .from(teamProjects)
@@ -36,9 +37,12 @@ export async function projectsByTeamId(teamId: string) {
     .all();
   const mapped = res.map((r) => r.projects);
   return mapped;
-}
+});
 
-export async function projectByTeamIdAndSlug(teamId: string, slug: string) {
+export const projectByTeamIdAndSlug = cache(async function (
+  teamId: string,
+  slug: string
+) {
   const res = await db
     .select({ projects })
     .from(teamProjects)
@@ -47,10 +51,10 @@ export async function projectByTeamIdAndSlug(teamId: string, slug: string) {
     .get();
   // TODO: Figure out how drizzle handles not found even though the return type isn't optional.
   return res.projects ? res.projects : undefined;
-}
+});
 
 // TODO: Where does this belong?
-export async function projectTeamByProjectId(projectId: string) {
+export const projectTeamByProjectId = cache(async function (projectId: string) {
   const res = await db
     .select({ teams })
     .from(teamProjects)
@@ -59,9 +63,9 @@ export async function projectTeamByProjectId(projectId: string) {
     .orderBy(teams.name)
     .get();
   return res.teams;
-}
+});
 
-export async function isAuthorizedForProject(
+export const isAuthorizedForProject = cache(async function (
   teamId: string,
   projectId: string
 ) {
@@ -76,4 +80,4 @@ export async function isAuthorizedForProject(
     )
     .get();
   return !!authorized;
-}
+});

--- a/db/api/tables.ts
+++ b/db/api/tables.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from "crypto";
 import { and, eq } from "drizzle-orm";
+import { cache } from "react";
 import { Table } from "../schema";
 import { db, projectTables, slugify, tables, tbl } from "./db";
 
-export async function createTable(
+export const createTable = cache(async function (
   projectId: string,
   name: string,
   description: string | null,
@@ -25,9 +26,9 @@ export async function createTable(
   ]);
   const table: Table = { id: tableId, name, description, schema, slug };
   return table;
-}
+});
 
-export async function tablesByProjectId(projectId: string) {
+export const tablesByProjectId = cache(async function (projectId: string) {
   const res = await db
     .select({ tables })
     .from(projectTables)
@@ -37,4 +38,4 @@ export async function tablesByProjectId(projectId: string) {
     .all();
   const mapped = res.map((r) => r.tables);
   return mapped;
-}
+});

--- a/db/api/teams.ts
+++ b/db/api/teams.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import { and, asc, eq } from "drizzle-orm";
 import { sealData } from "iron-session";
+import { cache } from "react";
 import { NewTeamInviteSealed, Team, TeamInvite, teamProjects } from "../schema";
 import {
   db,
@@ -13,7 +14,7 @@ import {
   users,
 } from "./db";
 
-export async function createTeamByPersonalTeam(
+export const createTeamByPersonalTeam = cache(async function (
   name: string,
   personalTeamId: string,
   inviteEmails: string[]
@@ -63,19 +64,19 @@ export async function createTeamByPersonalTeam(
   }
   await tbl.batch(batch);
   return { team, invites };
-}
+});
 
-export async function teamBySlug(slug: string) {
+export const teamBySlug = cache(async function (slug: string) {
   const team = await db.select().from(teams).where(eq(teams.slug, slug)).get();
   // TODO: Figure out how drizzle handles not found even though the return type isn't optional.
   return team ? team : undefined;
-}
+});
 
-export async function teamById(id: string) {
+export const teamById = cache(async function (id: string) {
   return db.select().from(teams).where(eq(teams.id, id)).get();
-}
+});
 
-export async function teamsByMemberId(memberId: string) {
+export const teamsByMemberId = cache(async function (memberId: string) {
   const res = await db
     .select()
     .from(teamMemberships)
@@ -148,9 +149,9 @@ export async function teamsByMemberId(memberId: string) {
   //     projects,
   //   };
   // });
-}
+});
 
-export async function userTeamsForTeamId(teamId: string) {
+export const userTeamsForTeamId = cache(async function (teamId: string) {
   const res = await db
     .select({ teams, users })
     .from(users)
@@ -160,9 +161,9 @@ export async function userTeamsForTeamId(teamId: string) {
     .orderBy(teams.name)
     .all();
   return res.map((r) => ({ address: r.users.address, personalTeam: r.teams }));
-}
+});
 
-export async function isAuthorizedForTeam(
+export const isAuthorizedForTeam = cache(async function (
   memberTeamId: string,
   teamId: string
 ) {
@@ -177,4 +178,4 @@ export async function isAuthorizedForTeam(
     )
     .get();
   return !!membership;
-}
+});


### PR DESCRIPTION
NextJS attempts to cache data fetches during rendering of server components. Using `fetch` API will, by default, be cached, but if you use your own data fetching library (like we do using the Tableland SDK), you have to manually declare what should be cached. I wrapped all `db` API functions in the `cache` higher order function. My hope is to use a blanket approach like this, and not think about if some db API functions should be cached and others not. I think the blanket approach is fine for now, but we can adjust later if we see some problem. To be clear, this is just caching fetched data for the duration of a single page render within the context of a single request. Essentially data fetching de-duplication. You can read more about it in the NextJS docs: https://nextjs.org/docs/app/building-your-application/data-fetching