### PR TITLE
update tableland sdk with recent bug fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31386,7 +31386,7 @@
         "@radix-ui/react-tooltip": "^1.0.6",
         "@react-email/components": "0.0.7",
         "@react-email/render": "0.0.7",
-        "@tableland/sdk": "^4.5.0",
+        "@tableland/sdk": "^4.5.1",
         "@tanstack/react-query": "^4.29.12",
         "@tanstack/react-table": "^8.9.3",
         "@toruslabs/eccrypto": "^3.0.0",
@@ -31423,6 +31423,17 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "packages/app/node_modules/@tableland/sdk": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.5.1.tgz",
+      "integrity": "sha512-ffvZYA9v6eNFsPYWtYJFfPT48rgtPIY4VTdcJbV2so7r4XGPw7JY4qdkWNO+2J8l4vOR9dusiSOHKVhHsNWeOA==",
+      "dependencies": {
+        "@async-generators/from-emitter": "^0.3.0",
+        "@tableland/evm": "^4.3.0",
+        "@tableland/sqlparser": "^1.3.0",
+        "ethers": "^5.7.2"
       }
     },
     "packages/app/node_modules/brace-expansion": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -32,7 +32,7 @@
     "@radix-ui/react-tooltip": "^1.0.6",
     "@react-email/components": "0.0.7",
     "@react-email/render": "0.0.7",
-    "@tableland/sdk": "^4.5.0",
+    "@tableland/sdk": "^4.5.1",
     "@tanstack/react-query": "^4.29.12",
     "@tanstack/react-table": "^8.9.3",
     "@toruslabs/eccrypto": "^3.0.0",


### PR DESCRIPTION
This bumps the `app`'s `@tableland/sdk` dependency to the latest patch version, which fixes the issue with building the `app`