### PR TITLE
Open up API access where possible

### DIFF
--- a/packages/api/src/routers/environments.ts
+++ b/packages/api/src/routers/environments.ts
@@ -1,11 +1,11 @@
 import { Store } from "@tableland/studio-store";
 import { z } from "zod";
-import { projectProcedure, router } from "../trpc";
+import { projectProcedure, publicProcedure, router } from "../trpc";
 
 export function environmentsRouter(store: Store) {
   return router({
-    projectEnvironments: projectProcedure(store)
-      .input(z.object({}))
+    projectEnvironments: publicProcedure
+      .input(z.object({ projectId: z.string() }))
       .query(async ({ input }) => {
         return await store.environments.getEnvironmentsByProjectId(
           input.projectId,

--- a/packages/api/src/routers/invites.ts
+++ b/packages/api/src/routers/invites.ts
@@ -57,18 +57,6 @@ export function invitesRouter(
         }
         return invite;
       }),
-    inviteById: publicProcedure
-      .input(z.object({ inviteId: z.string() }))
-      .query(async ({ input }) => {
-        const invite = await store.invites.inviteById(input.inviteId);
-        if (!invite) {
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Invite not found",
-          });
-        }
-        return invite;
-      }),
     acceptInvite: protectedProcedure
       .input(z.object({ seal: z.string() }))
       .mutation(async ({ input, ctx }) => {

--- a/packages/api/src/routers/projects.ts
+++ b/packages/api/src/routers/projects.ts
@@ -17,8 +17,8 @@ export function projectsRouter(store: Store) {
         }
         return await store.projects.projectsByTeamId(teamId);
       }),
-    projectByTeamIdAndSlug: teamProcedure(store)
-      .input(z.object({ slug: z.string() }))
+    projectByTeamIdAndSlug: publicProcedure
+      .input(z.object({ teamId: z.string(), slug: z.string() }))
       .query(async ({ input }) => {
         const project = await store.projects.projectByTeamIdAndSlug(
           input.teamId,

--- a/packages/api/src/routers/tables.ts
+++ b/packages/api/src/routers/tables.ts
@@ -2,12 +2,12 @@ import { Validator, helpers } from "@tableland/sdk";
 import { Store } from "@tableland/studio-store";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { projectProcedure, router } from "../trpc";
+import { projectProcedure, publicProcedure, router } from "../trpc";
 
 export function tablesRouter(store: Store) {
   return router({
-    projectTables: projectProcedure(store)
-      .input(z.object({}))
+    projectTables: publicProcedure
+      .input(z.object({ projectId: z.string() }))
       .query(async ({ input }) => {
         return await store.tables.tablesByProjectId(input.projectId);
       }),

--- a/packages/api/src/routers/teams.ts
+++ b/packages/api/src/routers/teams.ts
@@ -6,7 +6,6 @@ import {
   publicProcedure,
   router,
   teamAdminProcedure,
-  teamProcedure,
 } from "../trpc";
 import { SendInviteFunc } from "../utils/sendInvite";
 
@@ -53,10 +52,12 @@ export function teamsRouter(store: Store, sendInvite: SendInviteFunc) {
         await Promise.all(invites.map((invite) => sendInvite(invite)));
         return team;
       }),
-    usersForTeam: teamProcedure(store).query(async ({ input }) => {
-      const people = await store.teams.userTeamsForTeamId(input.teamId);
-      return people;
-    }),
+    usersForTeam: publicProcedure
+      .input(z.object({ teamId: z.string() }))
+      .query(async ({ input }) => {
+        const people = await store.teams.userTeamsForTeamId(input.teamId);
+        return people;
+      }),
     toggleAdmin: teamAdminProcedure(store)
       .input(z.object({ userId: z.string() }))
       .mutation(async ({ input }) => {


### PR DESCRIPTION
In preparation for building an unauthenticated Project view, I opened up all API procedures that don't return sensitive data, making them `publicProcedure`s.