### PR TITLE
(mail): stop requiring postmark api for dev mode

### DIFF
--- a/packages/mail/src/index.ts
+++ b/packages/mail/src/index.ts
@@ -2,8 +2,8 @@ import { render } from "@react-email/render";
 import * as postmark from "postmark";
 import Invite from "./emails/invite";
 
-export function initMailApi(apiKey: string) {
-  const client = new postmark.ServerClient(apiKey);
+export function initMailApi(apiKey?: string) {
+  const client = getClient(apiKey);
   return {
     sendInvite: async (
       to: string,
@@ -21,6 +21,17 @@ export function initMailApi(apiKey: string) {
       return res;
     },
   };
+}
+
+const getClient = function (apiKey?: string) {
+  if (typeof apiKey !== "string" || apiKey.trim() === "") {
+    return {
+      sendEmail: function (data: any) {
+        console.log("Development Mode Email:", JSON.stringify(data, null, 4));
+      }
+    };
+  }
+  return new postmark.ServerClient(apiKey);
 }
 
 export type MailApi = ReturnType<typeof initMailApi>;


### PR DESCRIPTION
@asutula This is a small change that makes it easier to start a dev server and reduces the chance we accidentally send emails to "fake" addresses.  

Definitely open to alternatives. My goal is to remove the requirement for anyone developing studio to have a valid postmark api key that would .