### PR TITLE
(web) create single script to start in dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,6 @@ packages/*/.tablelandrc.json
 *.tsbuildinfo
 next-env.d.ts
 
+packages/web/scripts/validator/*.db*
 tables_31337.json
 .react-email

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:net": "node scripts/net-start.mjs",
+    "dev:all": "(sleep 30 && npm run dev) & npm run dev:net",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/packages/web/scripts/net-start.mjs
+++ b/packages/web/scripts/net-start.mjs
@@ -1,0 +1,38 @@
+import { LocalTableland } from "@tableland/local";
+import { spawn } from "child_process";
+import { unlinkSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const _dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const lt = new LocalTableland({
+  validatorDir: path.resolve(_dirname, "validator"),
+});
+
+const start = async function () {
+  try {
+    unlinkSync(path.resolve(_dirname, "..", "tables_31337.json"));
+  } catch (err) {
+    if (err.code !== "ENOENT") throw err;
+  }
+
+  await lt.start();
+
+  await new Promise((resolve) => setTimeout(() => resolve(), 5000));
+
+  spawn("npm", ["run", "exec-migrate"], {
+    cwd: path.resolve(_dirname, ".."),
+  });
+};
+
+start().catch(function (err) {
+  console.error("start failed with:", err);
+});
+
+const handle = async function () {
+  await lt.shutdown();
+};
+
+process.on("SIGINT", handle);
+process.on("SIGTERM", handle);

--- a/packages/web/scripts/validator/config.json
+++ b/packages/web/scripts/validator/config.json
@@ -1,0 +1,66 @@
+{
+  "Impl": "mesa",
+  "HTTP": {
+    "Port": "8080",
+    "RateLimInterval": "1s",
+    "MaxRequestPerInterval": 1000
+  },
+  "Gateway": {
+    "ExternalURIPrefix": "http://localhost:8080",
+    "AnimationRendererURI": "https://render.tableland.xyz"
+  },
+  "DB": {
+    "Port": "5432"
+  },
+  "TableConstraints": {
+    "MaxRowCount": 500000
+  },
+  "QueryConstraints": {
+    "MaxWriteQuerySize": 35000,
+    "MaxReadQuerySize": 35000
+  },
+  "Metrics": {
+    "Port": "9090"
+  },
+  "Log": {
+    "Human": true,
+    "Debug": true
+  },
+  "Analytics": {
+    "FetchExtraBlockInfo": true
+  },
+  "Backup": {
+    "Enabled": false
+  },
+  "TelemetryPublisher": {
+    "Enabled": false
+  },
+  "Chains": [
+    {
+      "Name": "Local Hardhat",
+      "ChainID": 31337,
+      "AllowTransactionRelay": true,
+      "Registry": {
+        "EthEndpoint": "ws://localhost:8545",
+        "ContractAddress": "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"
+      },
+      "Signer": {
+        "PrivateKey": "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+      },
+      "EventFeed": {
+        "ChainAPIBackoff": "15s",
+        "NewBlockPollFreq": "1s",
+        "MinBlockDepth": 1
+      },
+      "EventProcessor": {
+        "BlockFailedExecutionBackoff": "10s"
+      },
+      "NonceTracker": {
+        "CheckInterval": "10s",
+        "StuckInterval": "10m",
+        "MinBlockDepth": 1
+      },
+      "HashCalculationStep": 100
+    }
+  ]
+}


### PR DESCRIPTION
Based on the discussion in discord, this introduces a script that will start the web app in dev mode and the a sandbox tableland network with a single npm command.

To try it out, do `npm run dev:all`.  Keep in mind you do still have to manually install dependencies and have the correct env file, as per the README.