### PR TITLE
(client) publish a pre version of the studio client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40600,7 +40600,7 @@
       "dependencies": {
         "@tableland/sdk": "^4.5.3-dev.0",
         "@tableland/sqlparser": "^1.3.0",
-        "@tableland/studio-client": "^0.0.0",
+        "@tableland/studio-client": "^0.0.0-pre.0",
         "@toruslabs/broadcast-channel": "^8.0.0",
         "@toruslabs/openlogin-session-manager": "^2.0.0",
         "@toruslabs/openlogin-utils": "^4.7.0",
@@ -40646,7 +40646,7 @@
     },
     "packages/client": {
       "name": "@tableland/studio-client",
-      "version": "0.0.0",
+      "version": "0.0.0-pre.0",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@tableland/studio-api": "^1.0.0",
@@ -41299,7 +41299,7 @@
         "@radix-ui/react-tooltip": "^1.0.7",
         "@tableland/sdk": "^4.5.3-dev.0",
         "@tableland/studio-api": "^1.0.0",
-        "@tableland/studio-client": "^0.0.0",
+        "@tableland/studio-client": "^0.0.0-pre.0",
         "@tableland/studio-store": "^1.0.0",
         "@tanstack/react-table": "^8.10.1",
         "@trpc/client": "^10.38.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@tableland/sdk": "^4.5.3-dev.0",
     "@tableland/sqlparser": "^1.3.0",
-    "@tableland/studio-client": "^0.0.0",
+    "@tableland/studio-client": "^0.0.0-pre.0",
     "@toruslabs/broadcast-channel": "^8.0.0",
     "@toruslabs/openlogin-session-manager": "^2.0.0",
     "@toruslabs/openlogin-utils": "^4.7.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/studio-client",
-  "version": "0.0.0",
+  "version": "0.0.0-pre.0",
   "description": "A tRPC client for Studio",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -35,7 +35,7 @@
     "@radix-ui/react-tooltip": "^1.0.7",
     "@tableland/sdk": "^4.5.3-dev.0",
     "@tableland/studio-api": "^1.0.0",
-    "@tableland/studio-client": "^0.0.0",
+    "@tableland/studio-client": "^0.0.0-pre.0",
     "@tableland/studio-store": "^1.0.0",
     "@tanstack/react-table": "^8.10.1",
     "@trpc/client": "^10.38.4",


### PR DESCRIPTION
in order to enable https://github.com/tablelandnetwork/tableland-js/pull/48 the studio client will need to be on npm.  This PR sets the version to `0.0.0-pre.0`.  