### PR TITLE
(cli) login command ensures account is registered

### DIFF
--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -57,6 +57,10 @@ export const handler = async (
     // note: the api handles session cookie storage
     const res = await api.auth.login.mutate({ message, signature });
 
+    if (typeof res === "undefined") {
+      throw new Error(`cannot login with an unregistered address: ${wallet.address}`);
+    }
+
     logger.log(`You are logged in with address: ${wallet.address}`);
   } catch (err: any) {
     logger.error(err);

--- a/packages/cli/test/login.test.ts
+++ b/packages/cli/test/login.test.ts
@@ -20,8 +20,6 @@ const accounts = getAccounts();
 const defaultArgs = [
   "--store",
   path.join(_dirname, ".studioclisession.json"),
-  "--privateKey",
-  accounts[10].privateKey.slice(2),
   "--chain",
   "local-tableland",
   "--providerUrl",
@@ -41,9 +39,31 @@ describe("commands/login", function () {
     restore();
   });
 
+  test("cannot login with an unregistered wallet", async function () {
+    const consoleError = spy(logger, "error");
+    await yargs([
+      "login",
+      ...defaultArgs,
+      "--privateKey",
+      accounts[9].privateKey.slice(2)
+    ]).command<GlobalOptions>(mod).parse();
+
+    const res = consoleError.getCall(0).firstArg;
+
+    equal(
+      res,
+      `Error: cannot login with an unregistered address: ${accounts[9].address}`
+    );
+  });
+
   test("can login with wallet", async function () {
     const consoleLog = spy(logger, "log");
-    await yargs(["login", ...defaultArgs]).command<GlobalOptions>(mod).parse();
+    await yargs([
+      "login",
+      ...defaultArgs,
+      "--privateKey",
+      accounts[10].privateKey.slice(2)
+    ]).command<GlobalOptions>(mod).parse();
 
     const res = consoleLog.getCall(0).firstArg;
 


### PR DESCRIPTION
## Overview
This fixes the behavior of the login command if an unregistered account is used.

## Details
The `auth.login` api endpoint succeeds as long as the message is signed.  This means that you can call the endpoint with an account that isn't registered and get a success message.  The correct behavior is for the cli to inspect the response data and ensure that valid account info is returned before logging a success message.