### PR TITLE
(cli) set default api url during login

### DIFF
--- a/packages/cli/src/commands/import-csv.ts
+++ b/packages/cli/src/commands/import-csv.ts
@@ -17,6 +17,7 @@ import {
   normalizePrivateKey,
   toChecksumAddress,
   getApi,
+  getApiUrl,
   getProject,
   FileStore,
 } from "../utils.js";
@@ -30,8 +31,9 @@ export const handler = async (
   argv: Arguments<GlobalOptions>,
 ): Promise<void> => {
   try {
-    const { providerUrl, apiUrl, store, table, file } = argv;
+    const { providerUrl, apiUrl: apiUrlArg, store, table, file } = argv;
     const fileStore = new FileStore(store as string);
+    const apiUrl = getApiUrl({ apiUrl: apiUrlArg, store: fileStore})
     const api = getApi(fileStore, apiUrl as string);
     const projectId = getProject({ ...argv, store: fileStore });
     

--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -4,6 +4,7 @@ import { type GlobalOptions } from "../cli.js";
 import {
   logger,
   getApi,
+  getApiUrl,
   FileStore,
 } from "../utils.js";
 
@@ -14,9 +15,12 @@ export const handler = async (
   argv: Arguments<GlobalOptions>,
 ): Promise<void> => {
   try {
-    const { chain, providerUrl, apiUrl, store } = argv;
-    const fileStore = new FileStore(store);
-    const api = getApi(fileStore, apiUrl);
+    const { chain, providerUrl, apiUrl: apiUrlArg, store } = argv;
+    const fileStore = new FileStore(store as string);
+    const apiUrl = getApiUrl({ apiUrl: apiUrlArg, store: fileStore})
+    const api = getApi(fileStore, apiUrl as string);
+
+
 
     await api.auth.logout.mutate();
 

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -2,7 +2,7 @@ import type { Arguments } from "yargs";
 import yargs from "yargs";
 // import { createTeamByPersonalTeam } from "../../../db/api/teams.js";
 import { type GlobalOptions } from "../cli.js";
-import { FileStore, getApi, logger } from "../utils.js";
+import { FileStore, getApi, getApiUrl, logger } from "../utils.js";
 
 type Yargs = typeof yargs;
 
@@ -32,8 +32,10 @@ export const builder = function (args: Yargs) {
       },
       async function (argv) {
         try {
-          const { teamId, store, apiUrl } = argv;
-          const api = getApi(new FileStore(store as string), apiUrl as string);
+          const { teamId, store, apiUrl: apiUrlArg } = argv;
+          const fileStore = new FileStore(store as string);
+          const apiUrl = getApiUrl({ apiUrl: apiUrlArg as string, store: fileStore})
+          const api = getApi(fileStore, apiUrl as string);
 
           const query = typeof teamId === "string" && teamId.trim() !== "" ? { teamId } : undefined;
           const projects = await api.projects.teamProjects.query(query);

--- a/packages/cli/src/commands/team.ts
+++ b/packages/cli/src/commands/team.ts
@@ -2,7 +2,7 @@ import type { Arguments } from "yargs";
 import yargs from "yargs";
 
 import { type GlobalOptions } from "../cli.js";
-import { FileStore, getApi, logger, normalizePrivateKey } from "../utils.js";
+import { FileStore, getApi, getApiUrl, logger, normalizePrivateKey } from "../utils.js";
 
 type Yargs = typeof yargs;
 
@@ -30,8 +30,10 @@ export const builder = function (args: Yargs) {
       },
       async function (argv) {
         try {
-          const { identifier, store, apiUrl } = argv;
-          const api = getApi(new FileStore(store as string), apiUrl as string);
+          const { identifier, store, apiUrl: apiUrlArg } = argv;
+          const fileStore = new FileStore(store as string);
+          const apiUrl = getApiUrl({ apiUrl: apiUrlArg as string, store: fileStore})
+          const api = getApi(fileStore, apiUrl as string);
 
           let query;
           if (typeof identifier === "string" && identifier.trim() !== "") {

--- a/packages/cli/src/commands/unuse.ts
+++ b/packages/cli/src/commands/unuse.ts
@@ -26,6 +26,10 @@ export const handler = async (
         fileStore.remove("projectId");
         fileStore.save();
         break;
+      case "api":
+        fileStore.remove("apiUrl");
+        fileStore.save();
+        break;
       default:
         throw new Error(`cannot remove context for: ${context}`)
     }

--- a/packages/cli/src/commands/use.ts
+++ b/packages/cli/src/commands/use.ts
@@ -30,6 +30,10 @@ export const handler = async (
         fileStore.set("projectId", id);
         fileStore.save();
         break;
+      case "api":
+        fileStore.set("apiUrl", id);
+        fileStore.save();
+        break;
       default:
         throw new Error(`cannot set context for: ${context}`)
     }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -5,6 +5,7 @@ import { helpers } from "@tableland/sdk";
 import { API, api, ClientConfig } from "@tableland/studio-client";
 
 const sessionKey = "session-cookie";
+const DEFAULT_API_URL = "https://studio.tableland.xyz";
 
 export const getApi = function (fileStore?: FileStore, apiUrl?: string): API {
   const apiArgs: ClientConfig = {};
@@ -47,6 +48,17 @@ export const getTeam = function (
   if (typeof argv.teamId === "string") return argv.teamId;
 
   return argv.store.get<string>("teamId");
+};
+
+export const getApiUrl = function (
+  argv: { store: FileStore; apiUrl?: string; }
+) {
+  if (typeof argv.apiUrl === "string") return argv.apiUrl;
+
+  const storeApiUrl = argv.store.get<string>("apiUrl");
+  if (storeApiUrl) return storeApiUrl;
+
+  return DEFAULT_API_URL;
 };
 
 export class FileStore {


### PR DESCRIPTION
## Overview
The url of the api the cli will use will default to the production studio, but if a user logs in with a non-standard url then the default for their login session is set to the given value.

## Details
Each command that calls the api needs to know the api url.  Up until this PR the user would need to include the `--apiUrl` flag with each command.  Now that we have a production api running we can use that as the global default.  We also want to continue to allow the user to choose a custom url, which is needed for local dev, testing staging, etc...
This PR sets the production url value as the default, or lets the user set the session default by providing it at login, and lastly the user can always explicitly set the flag on a per call basis.