### PR TITLE
(cli) add import table command and rename import data command

### DIFF
--- a/packages/cli/src/commands/import-data.ts
+++ b/packages/cli/src/commands/import-data.ts
@@ -1,0 +1,179 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { Writable } from "stream";
+import { createInterface } from "readline";
+import type yargs from "yargs";
+import type { Arguments, CommandBuilder } from "yargs";
+import { parse } from "csv-parse";
+import chalk from "chalk";
+import { Auth } from "@tableland/studio-api";
+import { studioAliases } from "@tableland/studio-client";
+import { Database, helpers } from "@tableland/sdk";
+import { type GlobalOptions } from "../cli.js";
+import {
+  logger,
+  getChainIdFromTableName,
+  getWalletWithProvider,
+  normalizePrivateKey,
+  toChecksumAddress,
+  getApi,
+  getApiUrl,
+  getProject,
+  FileStore,
+} from "../utils.js";
+
+export const command = "import-data <table> <file>";
+export const desc = "write the content of a csv into an existing table";
+
+const maxStatementLength = 35000;
+
+export const handler = async (
+  argv: Arguments<GlobalOptions>,
+): Promise<void> => {
+  try {
+    const { providerUrl, apiUrl: apiUrlArg, store, table, file } = argv;
+    const fileStore = new FileStore(store as string);
+    const apiUrl = getApiUrl({ apiUrl: apiUrlArg, store: fileStore})
+    const api = getApi(fileStore, apiUrl as string);
+    const projectId = getProject({ ...argv, store: fileStore });
+    
+    // lookup environmentId by projectId
+    const environments = await api.environments.projectEnvironments.query({ projectId });
+    const environmentId = environments.find(env => env.name === "default")?.id;
+    if (typeof environmentId !== "string") {
+      throw new Error("could not get default environment");
+    }
+
+    const aliases = studioAliases({ environmentId, apiUrl });
+    const uuTableName = (await aliases.read())[table as string];
+    if (typeof uuTableName !== "string") {
+      throw new Error("could not find table in project");
+    }
+// TODO: need to reverse lookup uuTableName from table and projectId so
+    //       that the wallet can be connected to the right provider.
+    const chain = getChainIdFromTableName(uuTableName);
+    const privateKey = normalizePrivateKey(argv.privateKey);
+    const signer = await getWalletWithProvider({
+      privateKey,
+      chain,
+      providerUrl,
+    });
+
+    const db = new Database({
+      signer,
+      aliases,
+    });
+
+    const fileString = readFileSync(file as string).toString();
+    const dataObject = await parseCsvFile(fileString);
+
+    // TODO: parse csv and enforce the existence of the right headers
+    const headers = dataObject.slice(0, 1);
+    const rows = dataObject.slice(1);
+
+    const stmt = `INSERT INTO ${table}
+      (${headers.join(",")})
+      VALUES ${rows.map(function (row) {
+        return `(${row.join(",")})`
+      }).join(",")}
+    `;
+
+    const statementCount = Math.ceil(stmt.length / maxStatementLength);
+    const doImport = await confirmImport({
+      statementLength: stmt.length,
+      rowCount: rows.length,
+      wallet: signer.address,
+      statementCount,
+      table,
+    });
+
+    if (!doImport) return logger.log("aborting");
+    if (statementCount !== 1) {
+      throw new Error("multi statement import not implemented yet");
+    }
+
+    // TODO: split the rows into a set of sql statements that meet the
+    //       protocol size requirements and potentially execute the
+    //       statement(s) with database batch
+    const result = await db.prepare(stmt).all();
+
+    logger.log(
+`successfully inserted ${rows.length} row${rows.length === 1 ? "" : "s"} into ${table}
+  transaction receipt: ${chalk.gray.bold(JSON.stringify(result.meta?.txn, null, 4))}
+  project id: ${projectId}
+  environment id: ${environmentId}`
+    );
+  } catch (err: any) {
+    logger.error(err);
+  }
+};
+
+const parseCsvFile = async function (
+  file: string
+): Promise<Array<Array<string>>> {
+  return new Promise(function (resolve, reject) {
+    const parser = parse();
+    const rows: any[] = [];
+
+    parser.on('readable', function () {
+      let row;
+      while ((row = parser.read()) !== null) {
+        rows.push(row);
+      }
+    });
+
+    parser.on('error', function(err){
+      reject(err);
+    });
+
+    parser.on('end', function(){
+      resolve(rows);
+    });
+
+    parser.write(file);
+    parser.end();
+  });
+};
+
+async function confirmImport(info: {
+  statementLength: number;
+  statementCount: number;
+  rowCount: number;
+  table: unknown;
+  wallet: string;
+}): Promise<boolean> {
+  if (typeof info.table !== "string") {
+    throw new Error("table name is required");
+  }
+
+  return await new Promise((resolve) => {
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+
+
+    logger.log(
+      `You are about to use address: ${chalk.yellow(info.wallet)} to insert ${chalk.yellow(info.rowCount)} row${info.rowCount === 1 ? "" : "s"} into table ${chalk.yellow(info.table)}`
+    );
+    logger.log(
+      `This can be done with a total of ${chalk.yellow(info.statementCount)} statment${info.statementCount === 1 ? "" : "s"}`
+    );
+    logger.log(
+      `The total size of the statment${info.statementCount === 1 ? "" : "s"} is: ${chalk.yellow(info.statementLength)}`
+    );
+    rl.question(
+      `Do you want to continue? (${chalk.bold("y/n")}): `,
+      (answer) => {
+        const response = answer.trim().toLowerCase();
+        rl.close();
+
+        if (response === "y" || response === "yes") {
+          return resolve(true);
+        }
+
+        resolve(false);
+      }
+    );
+  });
+}

--- a/packages/cli/src/commands/import-table.ts
+++ b/packages/cli/src/commands/import-table.ts
@@ -12,7 +12,9 @@ import { Database, helpers } from "@tableland/sdk";
 import { type GlobalOptions } from "../cli.js";
 import {
   logger,
-  getChainFromTableName,
+  getChainIdFromTableName,
+  getTableIdFromTableName,
+  getPrefixFromTableName,
   getWalletWithProvider,
   normalizePrivateKey,
   toChecksumAddress,
@@ -22,8 +24,8 @@ import {
   FileStore,
 } from "../utils.js";
 
-export const command = "import <table> <file>";
-export const desc = "write the content of a csv into an existing table";
+export const command = "import-table <table> <project> <description> [name]";
+export const desc = "import an existing tableland table into a project with description and optionally with a new name";
 
 const maxStatementLength = 35000;
 
@@ -31,12 +33,25 @@ export const handler = async (
   argv: Arguments<GlobalOptions>,
 ): Promise<void> => {
   try {
-    const { providerUrl, apiUrl: apiUrlArg, store, table, file } = argv;
+    const {
+      providerUrl,
+      apiUrl: apiUrlArg,
+      store,
+      table: uuTableName,
+      project,
+      name,
+      description,
+    } = argv;
+
+    if (typeof description !== "string" || description.trim() === "") {
+      throw new Error(`table description is required`);
+    }
+
     const fileStore = new FileStore(store as string);
     const apiUrl = getApiUrl({ apiUrl: apiUrlArg, store: fileStore})
     const api = getApi(fileStore, apiUrl as string);
     const projectId = getProject({ ...argv, store: fileStore });
-    
+
     // lookup environmentId by projectId
     const environments = await api.environments.projectEnvironments.query({ projectId });
     const environmentId = environments.find(env => env.name === "default")?.id;
@@ -44,64 +59,28 @@ export const handler = async (
       throw new Error("could not get default environment");
     }
 
-    const aliases = studioAliases({ environmentId, apiUrl });
-    const uuTableName = (await aliases.read())[table as string];
     if (typeof uuTableName !== "string") {
-      throw new Error("could not find table in project");
-    }
-// TODO: need to reverse lookup uuTableName from table and projectId so
-    //       that the wallet can be connected to the right provider.
-    const chain = getChainFromTableName(uuTableName);
-    const privateKey = normalizePrivateKey(argv.privateKey);
-    const signer = await getWalletWithProvider({
-      privateKey,
-      chain,
-      providerUrl,
-    });
-
-    const db = new Database({
-      signer,
-      aliases,
-    });
-
-    const fileString = readFileSync(file as string).toString();
-    const dataObject = await parseCsvFile(fileString);
-
-    // TODO: parse csv and enforce the existence of the right headers
-    const headers = dataObject.slice(0, 1);
-    const rows = dataObject.slice(1);
-
-    const stmt = `INSERT INTO ${table}
-      (${headers.join(",")})
-      VALUES ${rows.map(function (row) {
-        return `(${row.join(",")})`
-      }).join(",")}
-    `;
-
-    const statementCount = Math.ceil(stmt.length / maxStatementLength);
-    const doImport = await confirmImport({
-      statementLength: stmt.length,
-      rowCount: rows.length,
-      wallet: signer.address,
-      statementCount,
-      table,
-    });
-
-    if (!doImport) return logger.log("aborting");
-    if (statementCount !== 1) {
-      throw new Error("multi statement import not implemented yet");
+      throw new Error("must provide full tableland table name");
     }
 
-    // TODO: split the rows into a set of sql statements that meet the
-    //       protocol size requirements and potentially execute the
-    //       statement(s) with database batch
-    const result = await db.prepare(stmt).all();
+    const chainId = getChainIdFromTableName(uuTableName);
+    const tableId = getTableIdFromTableName(uuTableName).toString();
+    const prefix = (name as string) || getPrefixFromTableName(uuTableName);
+
+    await api.tables.importTable.mutate({
+      chainId,
+      tableId,
+      projectId,
+      name: prefix,
+      environmentId,
+      description,
+    });
 
     logger.log(
-`successfully inserted ${rows.length} row${rows.length === 1 ? "" : "s"} into ${table}
-  transaction receipt: ${chalk.gray.bold(JSON.stringify(result.meta?.txn, null, 4))}
-  project id: ${projectId}
-  environment id: ${environmentId}`
+`successfully imported ${uuTableName}
+  projectId: ${projectId}
+  name: ${name}
+  description: ${description}`
     );
   } catch (err: any) {
     logger.error(err);

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -2,8 +2,9 @@ import * as login from "./login.js";
 import * as logout from "./logout.js";
 import * as team from "./team.js";
 import * as project from "./project.js";
-import * as importCsv from "./import-csv.js";
+import * as importData from "./import-data.js";
+import * as importTable from "./import-table.js";
 import * as use from "./use.js";
 import * as unuse from "./unuse.js";
 
-export const commands = [login, logout, team, project, importCsv, unuse, use];
+export const commands = [login, logout, team, project, importData, importTable, unuse, use];

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -11,6 +11,7 @@ export const getApi = function (fileStore?: FileStore, apiUrl?: string): API {
   const apiArgs: ClientConfig = {};
 
   if (fileStore) {
+    // read response headers and save cookie in session json file
     apiArgs.fetch = function (res) {
       const setCookie = res.headers.get("set-cookie");
 
@@ -20,6 +21,7 @@ export const getApi = function (fileStore?: FileStore, apiUrl?: string): API {
       }
       return res;
     };
+    // set request cookie header if session json file has cookie
     apiArgs.headers = function () {
       const cookie = fileStore.get(sessionKey);
 
@@ -145,6 +147,7 @@ export const getChains = function (): typeof helpers.supportedChains {
     ),
   ) as Record<helpers.ChainName, helpers.ChainInfo>;
 };
+
 export function getChainName(
   chain: number | helpers.ChainName,
 ): helpers.ChainName {
@@ -155,16 +158,31 @@ export function getChainName(
   return chain;
 }
 
-export function getChainFromTableName(tableName: string) {
+export function getChainIdFromTableName(tableName: string) {
+  return getIdFromTableName(tableName, 2);
+}
+
+export function getTableIdFromTableName(tableName: string) {
+  return getIdFromTableName(tableName, 1);
+}
+
+function getIdFromTableName(tableName: string, revIndx: number) {
   const parts = tableName.trim().split("_");
   if (parts.length < 3) throw new Error("invalid table name");
 
-  const chainId = parseInt(parts[parts.length - 2], 10);
-  if (isNaN(chainId)) {
+  const id = parseInt(parts[parts.length - revIndx], 10);
+  if (isNaN(id)) {
     throw new Error("invalid table name");
   }
 
-  return chainId;
+  return id;
+}
+
+export function getPrefixFromTableName(tableName: string) {
+  const parts = tableName.trim().split("_");
+  if (parts.length < 3) throw new Error("invalid table name");
+
+  return parts.slice(0, -2).join("_");
 }
 
 export interface Options {


### PR DESCRIPTION
This should wait until after #96 is merged

## Overview
This adds the `import-table` command, and renames the `import` command to `import-data`

## Details
`import-table` does the same thing as the web app import functionality.  It imports an existing table from global Tableland into a Studio project

`import-data` is just a rename of the `import` command.  This removes ambiguity of the term "import"