### PR TITLE
add publish config and prep all packages besides `web` for publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40335,12 +40335,12 @@
     },
     "packages/api": {
       "name": "@tableland/studio-api",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "0.0.0-pre.0",
+      "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@tableland/sdk": "^4.5.3-dev.0",
-        "@tableland/studio-mail": "^0.0.0",
-        "@tableland/studio-store": "^1.0.0",
+        "@tableland/studio-mail": "^0.0.0-pre.0",
+        "@tableland/studio-store": "^0.0.0-pre.0",
         "@trpc/server": "^10.38.4",
         "iron-session": "^6.3.1",
         "next": "13.5.3",
@@ -40600,12 +40600,12 @@
     },
     "packages/cli": {
       "name": "@tableland/studio-cli",
-      "version": "0.0.0-pre.0",
+      "version": "0.0.0-pre.3",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@tableland/sdk": "^4.5.3-dev.0",
         "@tableland/sqlparser": "^1.3.0",
-        "@tableland/studio-client": "^0.0.0",
+        "@tableland/studio-client": "0.0.0-pre.0",
         "@toruslabs/broadcast-channel": "^8.0.0",
         "@toruslabs/openlogin-session-manager": "^2.0.0",
         "@toruslabs/openlogin-utils": "^4.7.0",
@@ -40617,6 +40617,7 @@
         "ethers": "^5.7.1",
         "inquirer": "^9.1.2",
         "js-yaml": "^4.1.0",
+        "keccak": "^3.0.1",
         "readline": "^1.3.0",
         "table": "^6.8.1",
         "yargs": "^17.6.2"
@@ -40664,10 +40665,10 @@
     },
     "packages/client": {
       "name": "@tableland/studio-client",
-      "version": "0.0.0",
+      "version": "0.0.0-pre.0",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
-        "@tableland/studio-api": "^1.0.0",
+        "@tableland/studio-api": "^0.0.0-pre.0",
         "@trpc/client": "^10.38.4",
         "superjson": "^1.13.1"
       }
@@ -40685,7 +40686,8 @@
     },
     "packages/mail": {
       "name": "@tableland/studio-mail",
-      "version": "0.0.0",
+      "version": "0.0.0-pre.0",
+      "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@react-email/components": "0.0.6",
         "postmark": "^3.0.19",
@@ -41273,8 +41275,8 @@
     },
     "packages/store": {
       "name": "@tableland/studio-store",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "0.0.0-pre.0",
+      "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@tableland/sdk": "^4.5.3-dev.0",
         "drizzle-orm": "^0.28.5",
@@ -41316,9 +41318,9 @@
         "@radix-ui/react-toast": "^1.1.5",
         "@radix-ui/react-tooltip": "^1.0.7",
         "@tableland/sdk": "^4.5.3-dev.0",
-        "@tableland/studio-api": "^1.0.0",
-        "@tableland/studio-client": "^0.0.0",
-        "@tableland/studio-store": "^1.0.0",
+        "@tableland/studio-api": "^0.0.0-pre.0",
+        "@tableland/studio-client": "^0.0.0-pre.0",
+        "@tableland/studio-store": "^0.0.0-pre.0",
         "@tanstack/react-table": "^8.10.1",
         "@trpc/client": "^10.38.4",
         "@trpc/next": "^10.38.4",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@tableland/studio-api",
-  "private": true,
-  "version": "1.0.0",
+  "version": "0.0.0-pre.0",
   "description": "",
+  "repository": "https://github.com/tablelandnetwork/studio/api",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,11 +15,11 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT AND Apache-2.0",
   "dependencies": {
     "@tableland/sdk": "^4.5.3-dev.0",
-    "@tableland/studio-mail": "^0.0.0",
-    "@tableland/studio-store": "^1.0.0",
+    "@tableland/studio-mail": "^0.0.0-pre.0",
+    "@tableland/studio-store": "^0.0.0-pre.0",
     "@trpc/server": "^10.38.4",
     "iron-session": "^6.3.1",
     "next": "13.5.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/studio-cli",
-  "version": "0.0.0-pre.0",
+  "version": "0.0.0-pre.3",
   "description": "Tableland command line tools",
   "repository": "https://github.com/tablelandnetwork/studio/cli",
   "publishConfig": {
@@ -46,7 +46,7 @@
   "dependencies": {
     "@tableland/sdk": "^4.5.3-dev.0",
     "@tableland/sqlparser": "^1.3.0",
-    "@tableland/studio-client": "^0.0.0",
+    "@tableland/studio-client": "0.0.0-pre.0",
     "@toruslabs/broadcast-channel": "^8.0.0",
     "@toruslabs/openlogin-session-manager": "^2.0.0",
     "@toruslabs/openlogin-utils": "^4.7.0",
@@ -58,6 +58,7 @@
     "ethers": "^5.7.1",
     "inquirer": "^9.1.2",
     "js-yaml": "^4.1.0",
+    "keccak": "^3.0.1",
     "readline": "^1.3.0",
     "table": "^6.8.1",
     "yargs": "^17.6.2"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,18 +1,21 @@
 {
   "name": "@tableland/studio-client",
-  "private": true,
-  "version": "0.0.0",
+  "version": "0.0.0-pre.0",
   "description": "A tRPC client for Studio",
+  "repository": "https://github.com/tablelandnetwork/studio/client",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
+  "types": "./dist/index.d.js",
+  "files": [
+    "dist/**/*.js"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tablelandnetwork/studio.git"
   },
   "keywords": [
     "tableland",
@@ -30,7 +33,7 @@
   },
   "homepage": "https://github.com/tablelandnetwork/studio#readme",
   "dependencies": {
-    "@tableland/studio-api": "^1.0.0",
+    "@tableland/studio-api": "^0.0.0-pre.0",
     "@trpc/client": "^10.38.4",
     "superjson": "^1.13.1"
   }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,4 @@
-import { AppRouter } from "@tableland/studio-api";
+import { type AppRouter } from "@tableland/studio-api";
 import { helpers } from "@tableland/sdk";
 import {
   createTRPCProxyClient,

--- a/packages/mail/package.json
+++ b/packages/mail/package.json
@@ -1,8 +1,10 @@
 {
   "name": "@tableland/studio-mail",
-  "private": true,
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.0.0-pre.0",
+  "repository": "https://github.com/tablelandnetwork/studio/mail",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,6 +14,7 @@
     "build": "tsc",
     "clean": "rm -rf dist"
   },
+  "license": "MIT AND Apache-2.0",
   "dependencies": {
     "@react-email/components": "0.0.6",
     "postmark": "^3.0.19",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@tableland/studio-store",
-  "private": true,
-  "version": "1.0.0",
+  "version": "0.0.0-pre.0",
   "description": "",
+  "repository": "https://github.com/tablelandnetwork/studio/store",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,7 +15,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT AND Apache-2.0",
   "dependencies": {
     "@tableland/sdk": "^4.5.3-dev.0",
     "drizzle-orm": "^0.28.5",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableland/studio",
-  "version": "0.0.0",
   "private": true,
+  "version": "0.0.0",
   "scripts": {
     "dev": "next dev",
     "dev:net": "node scripts/net-start.mjs",
@@ -34,9 +34,9 @@
     "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@tableland/sdk": "^4.5.3-dev.0",
-    "@tableland/studio-api": "^1.0.0",
-    "@tableland/studio-client": "^0.0.0",
-    "@tableland/studio-store": "^1.0.0",
+    "@tableland/studio-api": "^0.0.0-pre.0",
+    "@tableland/studio-client": "^0.0.0-pre.0",
+    "@tableland/studio-store": "^0.0.0-pre.0",
     "@tanstack/react-table": "^8.10.1",
     "@trpc/client": "^10.38.4",
     "@trpc/next": "^10.38.4",


### PR DESCRIPTION
## Overview
This updates the package.json files for the packages that need to be published to enable the studio on npm.

## Details
The `web` package is the only package not being published to npm.  I set all the packages versions to `0.0.0-pre.x`.  I'm thinking that shen we have had a chance to investigate internally, and are happy with the cli, we should publish `0.0.0`