### PR TITLE
use select element to choose chain instead of text input

### DIFF
--- a/packages/web/app/[team]/[project]/(project)/deployments/[[...slug]]/_components/exec-deployment.tsx
+++ b/packages/web/app/[team]/[project]/(project)/deployments/[[...slug]]/_components/exec-deployment.tsx
@@ -45,7 +45,7 @@ export default function ExecDeployment({
 }) {
   const router = useRouter();
   const [showDialog, setShowDialog] = useState(false);
-  const [selectedChain, setSelectedChain] = useState("");
+  const [chainId, setChainId] = useState<number | undefined>(undefined);
   const [pendingDeploy, startDeployTransition] = useTransition();
   const [signerState, setSignerState] = useState<
     "pending" | "processing" | "complete" | Error
@@ -66,14 +66,15 @@ export default function ExecDeployment({
 
   const handleDeploy = async () => {
     startDeployTransition(async () => {
-      let chainId: number;
       let signer: providers.JsonRpcSigner;
       let tbl: Database;
       let txn: WaitableTransactionReceipt;
 
       setSignerState("processing");
       try {
-        chainId = Number.parseInt(selectedChain);
+        if (!chainId) {
+          throw new Error("No chain selected");
+        }
         const currentNetwork = getNetwork();
         if (currentNetwork.chain?.id !== chainId) {
           await switchNetwork({ chainId });
@@ -194,10 +195,7 @@ export default function ExecDeployment({
         </DialogHeader>
         <div className="flex items-center gap-2">
           <Label>Deploy to</Label>
-          <ChainSelector
-            setValue={(val) => setSelectedChain(val)}
-            isDisabled={pendingDeploy}
-          />
+          <ChainSelector onValueChange={setChainId} disabled={pendingDeploy} />
         </div>
         <DeployStep
           pendingText="Resolve signer"
@@ -237,7 +235,7 @@ export default function ExecDeployment({
           <Button
             type="submit"
             onClick={handleDeploy}
-            disabled={pendingDeploy || !selectedChain}
+            disabled={pendingDeploy || !chainId}
           >
             {pendingDeploy && <Loader2 className="mr-2 h-5 w-5 animate-spin" />}
             Deploy

--- a/packages/web/app/[team]/[project]/import-table/_components/import-table-form.tsx
+++ b/packages/web/app/[team]/[project]/import-table/_components/import-table-form.tsx
@@ -99,7 +99,7 @@ export default function ImportTableForm({ project, team, envs }: Props) {
               <FormLabel>Chain ID</FormLabel>
               <FormControl>
                 <ChainSelector
-                  setValue={(val) => setValue("chainId", parseInt(val, 10))}
+                  onValueChange={(val) => setValue("chainId", val)}
                 />
               </FormControl>
               <FormDescription>

--- a/packages/web/components/chain-selector.tsx
+++ b/packages/web/components/chain-selector.tsx
@@ -9,6 +9,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { chains } from "@/lib/chains";
+import { SelectProps } from "@radix-ui/react-select";
 import { type Chain } from "wagmi/chains";
 
 const groupedChains = Array.from(
@@ -33,14 +34,16 @@ const groupedChains = Array.from(
     .entries(),
 );
 
-interface Props {
-  setValue: (v: string) => void;
-  isDisabled?: boolean;
-}
+type Props = Omit<SelectProps, "onValueChange"> & {
+  onValueChange?(value: number): void;
+};
 
-export default function ChainSelector({ setValue, isDisabled }: Props) {
+export default function ChainSelector({
+  onValueChange = () => {},
+  ...rest
+}: Props) {
   return (
-    <Select onValueChange={(val) => setValue(val)} disabled={isDisabled}>
+    <Select {...rest} onValueChange={(val) => onValueChange(parseInt(val, 10))}>
       <SelectTrigger className="w-fit gap-x-2">
         <SelectValue placeholder="Select chain" />
       </SelectTrigger>


### PR DESCRIPTION
This fixes https://linear.app/tableland/issue/STU-147/chainid-needs-a-link-in-the-helper-text-in-import-table-ui

## Overview
The need to choose a supported chain exists throughout the web app.  This PR addresses an issue where a user was having trouble remembering chain IDs, and also creates a component for choosing a chain that can be reused throughout the web app.