### PR TITLE
fix(deps): use op goerli (not staging) via @tableland/sdk bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "packages/mail"
       ],
       "devDependencies": {
-        "@tableland/local": "^2.0.1",
+        "@tableland/local": "^2.1.0",
         "@types/cosmiconfig": "^6.0.0",
         "@types/inquirer": "^9.0.2",
         "@types/js-yaml": "^4.0.5",
@@ -7072,13 +7072,13 @@
       "integrity": "sha512-bQHV8R9Me8IaJoJ2vPG4rXcL7seB7YVuskr4f+f5RyOStSZetwzkWtoqDMl5erkBJy0lDRUnIR2WIkPiC0GJlg=="
     },
     "node_modules/@tableland/local": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-2.0.2.tgz",
-      "integrity": "sha512-bx0hjIbiyAYut3Jqky2+8Nwae+fHjaM8KQx/5kWr1LwSlasZWwvDaGWk6zOU59LSZAXaMlBMb4N54S09cW3vNg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@tableland/local/-/local-2.1.0.tgz",
+      "integrity": "sha512-5F1D4qLB8+CW5gbPYCgk5R7HQo72zDi0gxemvWBV+ZTaIh0rWbKlcmx1B3iF+D1L5HbJs3GXfFzZ/AHxDfEJPQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@tableland/sdk": "^4.4.2",
+        "@tableland/sdk": "^4.5.3",
         "@tableland/validator": "^1.8.1",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
@@ -7094,10 +7094,9 @@
       }
     },
     "node_modules/@tableland/sdk": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.5.1.tgz",
-      "integrity": "sha512-ffvZYA9v6eNFsPYWtYJFfPT48rgtPIY4VTdcJbV2so7r4XGPw7JY4qdkWNO+2J8l4vOR9dusiSOHKVhHsNWeOA==",
-      "dev": true,
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.5.3.tgz",
+      "integrity": "sha512-2uJexQovp/uPEYArVgTTBAlLNHR7vkxs9u2Jzn685xpo8bS9awS91qpHZxKeHNZj+voLqDmihlSpKa209jFSew==",
       "dependencies": {
         "@async-generators/from-emitter": "^0.3.0",
         "@tableland/evm": "^4.3.0",
@@ -40388,7 +40387,7 @@
       "version": "0.0.0-pre.0",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
-        "@tableland/sdk": "^4.5.3-dev.0",
+        "@tableland/sdk": "^4.5.3",
         "@tableland/studio-mail": "^0.0.0-pre.0",
         "@tableland/studio-store": "^0.0.0-pre.0",
         "@trpc/server": "^10.38.4",
@@ -40546,17 +40545,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "packages/api/node_modules/@tableland/sdk": {
-      "version": "4.5.3-dev.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.5.3-dev.0.tgz",
-      "integrity": "sha512-/DPLobOJliteQnS/L5hbkD9IhghR7cT8pzDmiWg3/ajg3UxmvGxnRkk1q+WplEMPkmhPzfgA0jk1aun68AzbQA==",
-      "dependencies": {
-        "@async-generators/from-emitter": "^0.3.0",
-        "@tableland/evm": "^4.3.0",
-        "@tableland/sqlparser": "^1.3.0",
-        "ethers": "^5.7.2"
-      }
-    },
     "packages/api/node_modules/nanoid": {
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
@@ -40653,7 +40641,7 @@
       "version": "0.0.0-pre.5",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
-        "@tableland/sdk": "^4.5.3-dev.0",
+        "@tableland/sdk": "^4.5.3",
         "@tableland/sqlparser": "^1.3.0",
         "@tableland/studio-client": "0.0.0-pre.0",
         "@toruslabs/broadcast-channel": "^8.0.0",
@@ -40674,17 +40662,6 @@
       },
       "bin": {
         "studio": "dist/cli.js"
-      }
-    },
-    "packages/cli/node_modules/@tableland/sdk": {
-      "version": "4.5.3-dev.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.5.3-dev.0.tgz",
-      "integrity": "sha512-/DPLobOJliteQnS/L5hbkD9IhghR7cT8pzDmiWg3/ajg3UxmvGxnRkk1q+WplEMPkmhPzfgA0jk1aun68AzbQA==",
-      "dependencies": {
-        "@async-generators/from-emitter": "^0.3.0",
-        "@tableland/evm": "^4.3.0",
-        "@tableland/sqlparser": "^1.3.0",
-        "ethers": "^5.7.2"
       }
     },
     "packages/cli/node_modules/@toruslabs/openlogin-utils": {
@@ -41328,20 +41305,9 @@
       "version": "0.0.0-pre.1",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
-        "@tableland/sdk": "^4.5.3-dev.0",
+        "@tableland/sdk": "^4.5.3",
         "drizzle-orm": "^0.28.5",
         "iron-session": "^6.3.1"
-      }
-    },
-    "packages/store/node_modules/@tableland/sdk": {
-      "version": "4.5.3-dev.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.5.3-dev.0.tgz",
-      "integrity": "sha512-/DPLobOJliteQnS/L5hbkD9IhghR7cT8pzDmiWg3/ajg3UxmvGxnRkk1q+WplEMPkmhPzfgA0jk1aun68AzbQA==",
-      "dependencies": {
-        "@async-generators/from-emitter": "^0.3.0",
-        "@tableland/evm": "^4.3.0",
-        "@tableland/sqlparser": "^1.3.0",
-        "ethers": "^5.7.2"
       }
     },
     "packages/web": {
@@ -41368,7 +41334,7 @@
         "@radix-ui/react-switch": "^1.0.3",
         "@radix-ui/react-toast": "^1.1.5",
         "@radix-ui/react-tooltip": "^1.0.7",
-        "@tableland/sdk": "^4.5.3-dev.0",
+        "@tableland/sdk": "^4.5.3",
         "@tableland/studio-api": "^0.0.0-pre.0",
         "@tableland/studio-client": "^0.0.0-pre.0",
         "@tableland/studio-store": "^0.0.0-pre.0",
@@ -41856,17 +41822,6 @@
       "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "packages/web/node_modules/@tableland/sdk": {
-      "version": "4.5.3-dev.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.5.3-dev.0.tgz",
-      "integrity": "sha512-/DPLobOJliteQnS/L5hbkD9IhghR7cT8pzDmiWg3/ajg3UxmvGxnRkk1q+WplEMPkmhPzfgA0jk1aun68AzbQA==",
-      "dependencies": {
-        "@async-generators/from-emitter": "^0.3.0",
-        "@tableland/evm": "^4.3.0",
-        "@tableland/sqlparser": "^1.3.0",
-        "ethers": "^5.7.2"
       }
     },
     "packages/web/node_modules/@trpc/client": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "lerna run build"
   },
   "devDependencies": {
-    "@tableland/local": "^2.0.1",
+    "@tableland/local": "^2.1.0",
     "@types/cosmiconfig": "^6.0.0",
     "@types/inquirer": "^9.0.2",
     "@types/js-yaml": "^4.0.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "MIT AND Apache-2.0",
   "dependencies": {
-    "@tableland/sdk": "^4.5.3-dev.0",
+    "@tableland/sdk": "^4.5.3",
     "@tableland/studio-mail": "^0.0.0-pre.0",
     "@tableland/studio-store": "^0.0.0-pre.0",
     "@trpc/server": "^10.38.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,7 @@
   },
   "license": "MIT AND Apache-2.0",
   "dependencies": {
-    "@tableland/sdk": "^4.5.3-dev.0",
+    "@tableland/sdk": "^4.5.3",
     "@tableland/sqlparser": "^1.3.0",
     "@tableland/studio-client": "0.0.0-pre.0",
     "@toruslabs/broadcast-channel": "^8.0.0",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "MIT AND Apache-2.0",
   "dependencies": {
-    "@tableland/sdk": "^4.5.3-dev.0",
+    "@tableland/sdk": "^4.5.3",
     "drizzle-orm": "^0.28.5",
     "iron-session": "^6.3.1"
   }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -34,7 +34,7 @@
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-tooltip": "^1.0.7",
-    "@tableland/sdk": "^4.5.3-dev.0",
+    "@tableland/sdk": "^4.5.3",
     "@tableland/studio-api": "^0.0.0-pre.0",
     "@tableland/studio-client": "^0.0.0-pre.0",
     "@tableland/studio-store": "^0.0.0-pre.0",


### PR DESCRIPTION
## Summary

The `@tableland/sdk` was not filtering out the OP Goerli staging chain, which is an internal-only environment, so OP testnet tables could not be created on the "correct" `optimism-goerli` network. Tables in the UI were being created on the incorrect chain since all of the underpinning logic was handled within the SDK alone—this PR bumps the SDK in order to use its bug fix. Also bumped `@tableland/local`. Closes [STU-176](https://linear.app/tableland/issue/STU-176/update-sdk-once-optimism-goerli-chain-usage-is-fixed).

## Details
Tested via local/dev Studio instance, producing a table on the correct chain:

![image](https://github.com/tablelandnetwork/studio/assets/13358940/0af8b5c9-fee5-485d-957a-1ff8d5c920aa)
