### PR TITLE
(cli) use command checks if uuids are valid

### DIFF
--- a/packages/cli/src/commands/use.ts
+++ b/packages/cli/src/commands/use.ts
@@ -5,6 +5,7 @@ import {
   logger,
   getApi,
   FileStore,
+  isUUID,
 } from "../utils.js";
 
 export const command = "use [context] [id]";
@@ -23,10 +24,12 @@ export const handler = async (
 
     switch (context) {
       case "team":
+        if (!isUUID(id)) throw new Error("invalid team id");
         fileStore.set("teamId", id);
         fileStore.save();
         break;
       case "project":
+        if (!isUUID(id)) throw new Error("invalid project id");
         fileStore.set("projectId", id);
         fileStore.save();
         break;

--- a/packages/cli/test/use.test.ts
+++ b/packages/cli/test/use.test.ts
@@ -57,6 +57,38 @@ describe("commands/use", function () {
     ]).command<GlobalOptions>(modLogout).parse();
   });
 
+  test("use command throws if project id is not valid", async function () {
+    const consoleError = spy(logger, "error");
+
+    await yargs([
+      "use",
+      "project",
+      "invalidprojectid",
+      ...defaultArgs,
+      "--privateKey",
+      accounts[10].privateKey.slice(2)
+    ]).command<GlobalOptions>(modUse).parse();
+
+    const err = consoleError.getCall(0).firstArg;
+    equal(err.message, "invalid project id");
+  });
+
+  test("use command throws if team id is not valid", async function () {
+    const consoleError = spy(logger, "error");
+
+    await yargs([
+      "use",
+      "team",
+      "invalidteamid",
+      ...defaultArgs,
+      "--privateKey",
+      accounts[10].privateKey.slice(2)
+    ]).command<GlobalOptions>(modUse).parse();
+
+    const err = consoleError.getCall(0).firstArg;
+    equal(err.message, "invalid team id");
+  });
+
   test("use command sets teamId for project command", async function () {
     await yargs([
       "login",


### PR DESCRIPTION
NOTE: this PR should wait until after #127 is merged.

The use command was able to accept any string as a value.  In the case of `use team` and `use project` the value must be a uuid for any following commands to work, so we should be erroring out if something other than a uuid is provided. 

The acceptance of any value is particularly confusing because people might want to `use` the project or team name, which will not work.