### PR TITLE
(cli) format help message better

### DIFF
--- a/packages/cli/src/commands/import-data.ts
+++ b/packages/cli/src/commands/import-data.ts
@@ -26,8 +26,9 @@ import {
   FileStore,
 } from "../utils.js";
 
+// note: abnormal spacing is needed to ensure help message is formatted correctly
 export const command = "import-data <table> <file>";
-export const desc = "write the content of a csv into an existing table";
+export const desc = "write the content of a csv into an  existing table";
 
 export const handler = async (
   argv: Arguments<GlobalOptions>,

--- a/packages/cli/src/commands/import-table.ts
+++ b/packages/cli/src/commands/import-table.ts
@@ -25,8 +25,9 @@ import {
   FileStore,
 } from "../utils.js";
 
-export const command = "import-table <table> <project> <description> [name]";
-export const desc = "import an existing tableland table into a project with description and optionally with a new name";
+// note: abnormal spacing is needed to ensure help message is formatted correctly
+export const command = "import-table <table> <project>   <description> [name]";
+export const desc = "import an existing tableland table  into a project with description and optionally with a new name";
 
 const maxStatementLength = 35000;
 

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -16,8 +16,9 @@ import {
   FileStore,
 } from "../utils.js";
 
+// note: abnormal spacing is needed to ensure help message is formatted correctly
 export const command = "login";
-export const desc = "create a login session via private key";
+export const desc = "create a login session via private  key";
 
 export const handler = async (
   argv: Arguments<GlobalOptions>,

--- a/packages/cli/src/commands/unuse.ts
+++ b/packages/cli/src/commands/unuse.ts
@@ -7,8 +7,9 @@ import {
   FileStore,
 } from "../utils.js";
 
+// note: abnormal spacing is needed to ensure help message is formatted correctly
 export const command = "unuse [context]";
-export const desc = "remove any existing id from the given context";
+export const desc = "remove any existing id from the     given context";
 
 export const handler = async (
   argv: Arguments<GlobalOptions>,

--- a/packages/cli/src/commands/use.ts
+++ b/packages/cli/src/commands/use.ts
@@ -7,8 +7,9 @@ import {
   FileStore,
 } from "../utils.js";
 
+// note: abnormal spacing is needed to ensure help message is formatted correctly
 export const command = "use [context] [id]";
-export const desc = "use the given context id for all ensuing commands";
+export const desc = "use the given context id for all    ensuing commands";
 
 export const handler = async (
   argv: Arguments<GlobalOptions>,


### PR DESCRIPTION
NOTE: this PR should wait until after #131 
The current help message is formatted by yargs.  Yargs simply cuts the string and starts a newline as soon as a specific character count is hit.  This results in new lines starting in the middle of words.

This PR simply adds spaces when needed to ensure no new lines start in the middle of words.

Before this change it looks like this:
<img width="574" alt="Screen Shot 2023-10-24 at 4 59 25 AM" src="https://github.com/tablelandnetwork/studio/assets/1500995/62cf4bae-b591-4e38-8d2a-d26c16db6ddb">

After this change it looks like:
<img width="560" alt="Screen Shot 2023-10-24 at 4 59 48 AM" src="https://github.com/tablelandnetwork/studio/assets/1500995/700c4910-9f57-4c4c-a614-e1935830db38">

