### PR TITLE
(api) add helper for logging internal server errors

### DIFF
--- a/packages/api/src/routers/tables.ts
+++ b/packages/api/src/routers/tables.ts
@@ -3,6 +3,7 @@ import { type Schema, type Store } from "@tableland/studio-store";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { projectProcedure, publicProcedure, router } from "../trpc";
+import { internalError } from "../utils/internalError";
 
 const schemaSchema: z.ZodType<Schema> = z.object({
   columns: z.array(
@@ -63,11 +64,7 @@ export function tablesRouter(store: Store) {
             input.schema,
           );
         } catch (err) {
-          throw new TRPCError({
-            code: "INTERNAL_SERVER_ERROR",
-            message: "Error saving table record.",
-            cause: err,
-          });
+          throw internalError("Error saving table record.", err);
         }
       }),
     importTable: projectProcedure(store)

--- a/packages/api/src/utils/internalError.ts
+++ b/packages/api/src/utils/internalError.ts
@@ -1,0 +1,13 @@
+import { TRPCError } from "@trpc/server";
+
+export function internalError(message: string, cause: unknown) {
+  // ensure we can read the full error in the server logs
+  console.log("internalError:");
+  console.error(cause);
+
+  return new TRPCError({
+    code: "INTERNAL_SERVER_ERROR",
+    message,
+    cause,
+  });
+}


### PR DESCRIPTION
I was able to reproduce a [user reported error](https://discord.com/channels/592843512312102924/968582612945870878/1179101065724039240) on production, but not locally.   We don't currently log actual errors on production afaict.  This PR adds an api helper that will log the error via `console.error`