### PR TITLE
log the error object when an internal server error occurs

### DIFF
--- a/packages/api/src/routers/auth.ts
+++ b/packages/api/src/routers/auth.ts
@@ -3,6 +3,7 @@ import { TRPCError } from "@trpc/server";
 import { generateNonce, SiweMessage } from "siwe";
 import { z } from "zod";
 import { protectedProcedure, publicProcedure, router } from "../trpc";
+import { internalError } from "../utils/internalError";
 
 export function authRouter(store: Store) {
   return router({
@@ -74,13 +75,8 @@ export function authRouter(store: Store) {
           ctx.session.auth = auth;
           await ctx.session.persist(ctx.responseCookies);
           return ctx.session.auth;
-        } catch (error) {
-          console.error("Error from store registering user:", error);
-          throw new TRPCError({
-            code: "INTERNAL_SERVER_ERROR",
-            message: "Error registering user",
-            cause: error,
-          });
+        } catch (err) {
+          throw internalError("Error registering user", err);
         }
       }),
     logout: protectedProcedure.input(z.void()).mutation(async ({ ctx }) => {

--- a/packages/api/src/routers/projects.ts
+++ b/packages/api/src/routers/projects.ts
@@ -2,6 +2,7 @@ import { type Store } from "@tableland/studio-store";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { publicProcedure, router, teamProcedure } from "../trpc";
+import { internalError } from "../utils/internalError";
 
 export function projectsRouter(store: Store) {
   return router({
@@ -87,12 +88,8 @@ export function projectsRouter(store: Store) {
             name: "default",
           });
           return project;
-        } catch (error) {
-          throw new TRPCError({
-            code: "INTERNAL_SERVER_ERROR",
-            message: "Error creating project",
-            cause: error,
-          });
+        } catch (err) {
+          throw internalError("Error creating project", err);
         }
       }),
   });

--- a/packages/api/src/routers/tables.ts
+++ b/packages/api/src/routers/tables.ts
@@ -95,11 +95,7 @@ export function tablesRouter(store: Store) {
               message: `Table id ${input.tableId} not found on chain ${input.chainId}.`,
             });
           }
-          throw new TRPCError({
-            code: "INTERNAL_SERVER_ERROR",
-            message: "Error getting table by id.",
-            cause: err,
-          });
+          throw internalError("Error getting table by id.", err);
         }
 
         const createdAttr = tablelandTable.attributes?.find(
@@ -130,11 +126,10 @@ export function tablesRouter(store: Store) {
           });
           return { table, deployment };
         } catch (err) {
-          throw new TRPCError({
-            code: "INTERNAL_SERVER_ERROR",
-            message: "Error saving table and deployment records.",
-            cause: err,
-          });
+          throw internalError(
+            "Error saving table and deployment records.",
+            err,
+          );
         }
       }),
   });

--- a/packages/api/src/routers/teams.ts
+++ b/packages/api/src/routers/teams.ts
@@ -8,6 +8,7 @@ import {
   teamAdminProcedure,
 } from "../trpc";
 import { type SendInviteFunc } from "../utils/sendInvite";
+import { internalError } from "../utils/internalError";
 
 export function teamsRouter(store: Store, sendInvite: SendInviteFunc) {
   return router({
@@ -97,12 +98,8 @@ export function teamsRouter(store: Store, sendInvite: SendInviteFunc) {
           );
           team = res.team;
           invites = res.invites;
-        } catch (e) {
-          throw new TRPCError({
-            code: "INTERNAL_SERVER_ERROR",
-            message: "Error creating team",
-            cause: e,
-          });
+        } catch (err) {
+          throw internalError("Error creating team", err);
         }
 
         // Intentionally swallowing any error here since the team is still

--- a/packages/cli/src/commands/team.ts
+++ b/packages/cli/src/commands/team.ts
@@ -6,12 +6,7 @@ import type { Arguments } from "yargs";
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import yargs from "yargs";
 import { type GlobalOptions } from "../cli.js";
-import {
-  FileStore,
-  getApi,
-  getApiUrl,
-  logger,
-} from "../utils.js";
+import { FileStore, getApi, getApiUrl, logger } from "../utils.js";
 
 type Yargs = typeof yargs;
 
@@ -94,10 +89,7 @@ export const builder = function (args: Yargs) {
         if (typeof store !== "string") {
           throw new Error("must provide path to session store file");
         }
-        if (
-          typeof apiUrlArg !== "string" &&
-          typeof apiUrlArg !== "undefined"
-        ) {
+        if (typeof apiUrlArg !== "string" && typeof apiUrlArg !== "undefined") {
           throw new Error("invalid apiUrl");
         }
 
@@ -107,10 +99,10 @@ export const builder = function (args: Yargs) {
 
         const result = await api.teams.newTeam.mutate({
           name,
-          emailInvites:(invites ?? "")
+          emailInvites: (invites ?? "")
             .split(",")
             .map((email) => email.trim())
-            .filter((i) => i)
+            .filter((i) => i),
         });
 
         logger.log(JSON.stringify(result));

--- a/packages/cli/test/team.test.ts
+++ b/packages/cli/test/team.test.ts
@@ -124,7 +124,5 @@ describe("commands/team", function () {
     equal(team.slug, teamName);
   });
 
-  test.skip("can add a user to a team", async function () {
-
-  });
+  test.skip("can add a user to a team", async function () {});
 });


### PR DESCRIPTION
If we encounter an unexpected error in the future this ensures that the error object is logged along with the response.
This will be helpful to whomever is debugging the cause of the error.

There are also some unrelated prettier fixes included here.