### PR TITLE
feat: redirect to team on root page sign in

### DIFF
--- a/packages/web/components/profile.tsx
+++ b/packages/web/components/profile.tsx
@@ -56,27 +56,30 @@ export default function Profile({
   useEffect(() => {
     // 1. check if user is already authenticated and redirect to personal team
     //    slug if not already there
-    const handler = async () => {
-      try {
-        const authResponse = await authenticated.refetch();
-        console.log("authenticated.refetch success");
+    const handler = () => {
+      void authenticated
+        .refetch()
+        .then((authResponse) => {
+          console.log("authenticated.refetch success");
+          const fetchedAuth = authResponse.data;
 
-        const fetchedAuth = authResponse.data;
-        if (fetchedAuth && !dontRedirect) {
-          const userSlug = fetchedAuth.personalTeam.slug;
-          if (pathname !== `/${userSlug}`) {
-            router.push(`/${userSlug}`);
+          if (fetchedAuth && !dontRedirect) {
+            const userSlug = fetchedAuth.personalTeam.slug;
+            if (pathname !== `/${userSlug}`) {
+              router.push(`/${userSlug}`);
+            }
           }
-        }
-      } catch (error: any) {
-        console.error(error);
-      }
+        })
+        .catch((error) => {
+          console.error(error);
+        });
     };
     handler();
     // 2. window is focused (in case user logs out of another window)
-    window.addEventListener("focus", handler);
-    return () => window.removeEventListener("focus", handler);
-  }, [authenticated]);
+    const focusHandler = () => handler();
+    window.addEventListener("focus", focusHandler);
+    return () => window.removeEventListener("focus", focusHandler);
+  }, [authenticated, dontRedirect, pathname, router]);
 
   useEffect(() => {
     // in order to keep types correct we need to use logical operator


### PR DESCRIPTION
## Summary 
When you log into the studio at the root endpoint, it doesn't redirect to my profile. This is confusing because as a user, I have to know that I must click the "Home" button in order to get to the correct route and show Studio functionality. This adds logic to redirect to the personal team route if the user has signed in.

## Details

For reference, here is a video of how the existing logic works. When you're signed in and go to the studio URL, it doesn't redirect anywhere, and you have to click "Home". (The new logic is shown down below, with a note.)


https://github.com/tablelandnetwork/studio/assets/13358940/733a7093-e116-47bc-b907-26537b172452


A simple change in the `profile` component adds this logic:
```tsx
const handler = () => {
  void authenticated
    .refetch()
    .then((authResponse) => {
      console.log("authenticated.refetch success");
      const fetchedAuth = authResponse.data;

      if (fetchedAuth && !dontRedirect) {
        const userSlug = fetchedAuth.personalTeam.slug;
        if (pathname !== `/${userSlug}`) {
          router.push(`/${userSlug}`);
        }
      }
    })
    .catch((error) => {
      console.error(error);
    });
};
```
vs.
```tsx
const handler = () => {
  authenticated
    .refetch()
    .then(() => console.log("authenticated.refetch success"))
    .catch((err) => console.error(err));
};
```

## Errors

I noticed that with both the exsting logic and the new logic implemented here, you can (very occasionally) run into a tRPC error upon signing in. The video shows how the new logic redirects to the personal team slug upon initial connections or subsequent sign ins. But, if you sign out and sign back really quickly, you'll sometimes run into an error:
```
Failed to load resource: the server responded with a status of 412 (Precondition Failed)
app-index.js:32  << mutation #5 auth.login Objectcontext: {}elapsedMs: 135input: {message: 'localhost:3000 wants you to sign in with your Ethe…XATaechi9Rafs\nIssued At: 2023-12-12T19:04:49.170Z', signature: '0x0ddebc24ef90343935077eb3628e4bacd6735542bbbb190c…9619f57ce4113be7e2b037bec5442cdad2b294be07d35111b'}result: TRPCClientError
    at TRPCClientError.from (webpack-internal:///(app-pages-browser)/./node_modules/@trpc/client/dist/TRPCClientError-0de4d231.mjs:31:20)
    at eval (webpack-internal:///(app-pages-browser)/./node_modules/@trpc/client/dist/httpBatchLink-cee1f56c.mjs:198:105)[[Prototype]]: Object
window.console.error @ app-index.js:32
Show 1 more frame
Show less
app-index.js:32 TRPCClientError
    at TRPCClientError.from (TRPCClientError-0de4d231.mjs:31:20)
    at eval (httpBatchLink-cee1f56c.mjs:198:105)
window.console.error @ app-index.js:32
```
Here's the video. The error occurs at the 40 second mark after repeated sign ins/outs, but after the error is shown, you can still successfully log in w/o issue. Thus, this seems like an edge case that shouldn't impact this PR imo.

https://github.com/tablelandnetwork/studio/assets/13358940/700e1e6a-9436-438f-be44-fa5c46a4be56

