### PR TITLE
Add a gas estimation message to command confirmation prompts 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4931,9 +4931,9 @@
       }
     },
     "node_modules/@tableland/sdk": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-5.1.0.tgz",
-      "integrity": "sha512-JZIKmvNeDdzAQ6u5/AgBoc1ovqjvvqs7oM8K2fPeEW8RGB3FiKdTnVhPbDJiRIVrndhnpv1Sfe521lZeQfHMzw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-5.2.0.tgz",
+      "integrity": "sha512-tqu6ByCm4oz1Ml/bZBeBYPeEsxW6pqbNY+VGV+PQ+UFpMU+cf4T202hki4s69F2nnE3HpgaPrXPKYD8Z55pU+Q==",
       "dependencies": {
         "@async-generators/from-emitter": "^0.3.0",
         "@tableland/evm": "^4.5.0",
@@ -22205,10 +22205,10 @@
     },
     "packages/cli": {
       "name": "@tableland/studio-cli",
-      "version": "0.0.0-pre.8",
+      "version": "0.0.0-pre.9",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
-        "@tableland/sdk": "^5.1.0",
+        "@tableland/sdk": "^5.2.0",
         "@tableland/sqlparser": "^1.3.0",
         "@tableland/studio-client": "0.0.0-pre.2",
         "chalk": "^5.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/studio-cli",
-  "version": "0.0.0-pre.8",
+  "version": "0.0.0-pre.9",
   "description": "Tableland command line tools",
   "repository": "https://github.com/tablelandnetwork/studio/cli",
   "publishConfig": {

--- a/packages/cli/src/commands/deployment.ts
+++ b/packages/cli/src/commands/deployment.ts
@@ -121,7 +121,7 @@ export const builder = function (args: Yargs) {
 
           const stmt = generateCreateTableStatement(table.name, table.schema);
 
-          const gas = await helpers.estimateGas({
+          const cost = await helpers.estimateCost({
             signer: wallet,
             chainId: chain as number,
             method: "create(address,string)",
@@ -133,7 +133,7 @@ export const builder = function (args: Yargs) {
             `You are about to use address: ${chalk.yellow(
               wallet.address,
             )} to deploy a table on chain ${chain as number}
-The estimated gas required is ${gas.toString()}
+The estimated cost is ${cost}
 Do you want to continue (y/n)? `,
           ]);
 

--- a/packages/cli/src/commands/import-data.ts
+++ b/packages/cli/src/commands/import-data.ts
@@ -135,7 +135,7 @@ async function confirmImport(info: {
   const statementCount = info.statements.length;
   const tableId = helpers.getTableIdFromTableName(info.table);
 
-  const gas = await helpers.estimateGas({
+  const cost = await helpers.estimateCost({
     signer: info.wallet,
     chainId: helpers.getChainIdFromTableName(info.table),
     method: "mutate(address,(uint256,string)[])",
@@ -154,7 +154,7 @@ This can be done with a total of ${chalk.yellow(statementCount)} statment${
 The total size of the statment${
       statementCount === 1 ? "" : "s"
     } is: ${chalk.yellow(statementLength)}
-The estimated gas required is ${gas.toString()}
+The estimated cost is ${cost}
 Do you want to continue (${chalk.bold("y/n")})? `,
   ]);
   const proceed = answers[0].toLowerCase()[0];

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -190,7 +190,7 @@ export const handler = async (
       chainId: number;
       args: any[];
     }) {
-      const gas = await helpers.estimateGas({
+      const cost = await helpers.estimateCost({
         signer: info.wallet,
         chainId: info.chainId,
         method: "mutate(address,uint256,string)",
@@ -201,7 +201,7 @@ export const handler = async (
         `You are about to use address: ${chalk.yellow(
           info.wallet.address,
         )} to write to a table on chain ${chalk.yellow(info.chainId)}
-The estimated gas required is ${gas.toString()}
+The estimated cost is ${cost}
 Do you want to continue (${chalk.bold("y/n")})? `,
       );
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,11 +1,12 @@
 import readline from "node:readline/promises";
 import { readFileSync, writeFileSync } from "node:fs";
 import {
+  type Signer,
   BigNumber,
   Wallet,
-  type Signer,
   getDefaultProvider,
   providers,
+  utils as ethersUtils,
 } from "ethers";
 import createKeccakHash from "keccak";
 import { helpers as sdkHelpers } from "@tableland/sdk";
@@ -213,6 +214,26 @@ function getIdFromTableName(tableName: string, revIndx: number) {
   return id;
 }
 
+// currency symbols for chains that don't use ETH
+const symbols: Record<number, string> = {
+  // matic
+  137: "MATIC",
+  // filecoin
+  314: "FIL",
+  // maticmum
+  80001: "MATIC",
+  // filecoin calibration
+  314159: "tFIL",
+};
+
+function getCurrencySymbol(chainId: number) {
+  if (typeof symbols[chainId] === "string") {
+    return symbols[chainId];
+  }
+
+  return "ETH";
+}
+
 export const helpers = {
   ask: async function (questions: string[]) {
     const rl = readline.createInterface({
@@ -251,7 +272,7 @@ export const helpers = {
     }
     return url.toString();
   },
-  estimateGas: async function (params: {
+  estimateCost: async function (params: {
     signer: Signer;
     chainId: number;
     method: string;
@@ -273,7 +294,21 @@ export const helpers = {
       throw new Error("could not get gas estimation");
     }
 
-    return gas;
+    const feeData = await params.signer.provider?.getFeeData();
+    // {
+    //   gasPrice: { BigNumber: "23238878592" },
+    //   lastBaseFeePerGas: { BigNumber: "23169890320" },
+    //   maxFeePerGas: { BigNumber: "47839780640" },
+    //   maxPriorityFeePerGas: { BigNumber: "1500000000" }
+    // }
+
+    if (feeData?.gasPrice) {
+      const costGwei = feeData?.gasPrice.mul(gas);
+      return `${ethersUtils.formatUnits(costGwei, 18)} ${getCurrencySymbol(
+        params.chainId,
+      )}`;
+    }
+    return "UNKNOWN";
   },
   findOrCreateDefaultEnvironment: async function (api: any, projectId: string) {
     try {

--- a/packages/cli/test/deployment.test.ts
+++ b/packages/cli/test/deployment.test.ts
@@ -1,10 +1,12 @@
 import path from "path";
 import { fileURLToPath } from "url";
 import { equal } from "node:assert";
+import readline from "node:readline/promises";
 import { getAccounts } from "@tableland/local";
 import mockStd from "mock-stdin";
+import chalk from "chalk";
 import { afterEach, before, describe, test } from "mocha";
-import { restore, spy } from "sinon";
+import { restore, spy, stub } from "sinon";
 import yargs from "yargs/yargs";
 import { type GlobalOptions } from "../src/cli.js";
 import * as mod from "../src/commands/deployment.js";
@@ -140,6 +142,48 @@ describe("commands/deployment", function () {
     equal(tokenIdNumber > 10, true);
     equal(isNaN(value.blockNumber), false);
     equal(typeof value.blockNumber, "number");
+  });
+
+  test("create deployment confirms with cost", async function () {
+    let message = "";
+    // @ts-expect-error we don't need the mock readline interface to have the right types
+    const rlStub = stub(readline, "createInterface").callsFake(function () {
+      return {
+        question: async function (qstn: string) {
+          message = qstn;
+        },
+      };
+    });
+
+    const stdin = mockStd.stdin();
+
+    setTimeout(() => {
+      stdin.send("n\n").end();
+      stdin.restore();
+    }, 1000);
+
+    await yargs([
+      "deployment",
+      "create",
+      "table2",
+      "--projectId",
+      projectId,
+      ...defaultArgs,
+    ])
+      .command(mod)
+      .parse();
+
+    rlStub.restore();
+    const lines = message.split("\n");
+
+    equal(
+      lines[0],
+      `You are about to use address: ${chalk.yellow(
+        "0xBcd4042DE499D14e55001CcbB24a551F3b954096",
+      )} to deploy a table on chain local-tableland`,
+    );
+    equal(lines[1].startsWith("The estimated cost is"), true);
+    equal(lines[2], "Do you want to continue (y/n)? ");
   });
 
   test("can list deployments", async function () {

--- a/packages/cli/test/sql/generate_test_data.sql
+++ b/packages/cli/test/sql/generate_test_data.sql
@@ -87,3 +87,25 @@ insert into `tables` (
 	'first test table',
 	'{"columns":[{"name":"id","type":"integer","constraints":["primary key"]},{"name":"info","type":"text"}]}'
 );
+--> statement-breakpoint
+insert into `project_tables` (
+	`project_id`,
+	`table_id`
+) values (
+	'2f403473-de7b-41ba-8d97-12a0344aeccb',
+	'48bcca5e-33ee-4461-a926-9ae5a1ce73f9'
+);
+--> statement-breakpoint
+insert into `tables` (
+	`id`,
+	`slug`,
+	`name`,
+	`description`,
+	`schema`
+) values (
+	'48bcca5e-33ee-4461-a926-9ae5a1ce73f9',
+	'table2',
+	'table2',
+	'second test table',
+	'{"columns":[{"name":"id","type":"integer","constraints":["primary key"]},{"name":"data","type":"text"}]}'
+);


### PR DESCRIPTION
NOTE: this requires the release of a new SDK that exports the `getContractAndOverrides` method. PR [in review](https://github.com/tablelandnetwork/tableland-js/pull/111).

## Overview
The `import-data`, `deployment create`, and `query` commands all potentially submit a transaction to the block chain using the user provided wallet.  In order to give the user better control over what is done with their funds, this PR adds a message explaining what the estimated amount of gas that would be used for the transaction.

## Details
The main addition included here is a helper function that wraps the ethers.js `contract.estimateGas` method.  This helper allows the caller to specify a method and arguments for the tableland registry contract. Given that info, we can get an estimate of the amount of gas needed.
In manual testing, the accuracy of the estimate is within reasonable limits.  Specifically, It's always been less than 10% off in my tests.  FYI: all of my tests were on the mumbai network.