### PR TITLE
(cli) add chain and provider to `use` and add chain to init

### DIFF
--- a/packages/cli/src/commands/deployment.ts
+++ b/packages/cli/src/commands/deployment.ts
@@ -71,7 +71,7 @@ export const builder = function (args: Yargs) {
       },
       async function (argv) {
         try {
-          const { chain, name, store, apiUrl: apiUrlArg, providerUrl } = argv;
+          const { chain, name, store, apiUrl: apiUrlArg } = argv;
 
           const chainInfo = sdkHelpers.getChainInfo(chain as number);
           const fileStore = new FileStore(store as string);
@@ -86,11 +86,15 @@ export const builder = function (args: Yargs) {
             ...argv,
             store: fileStore,
           });
+          const providerUrl = helpers.getProviderUrl({
+            providerUrl: argv.providerUrl,
+            store: fileStore,
+          });
 
           const wallet = await helpers.getWalletWithProvider({
             privateKey,
             chain: chainInfo.chainId,
-            providerUrl: providerUrl as string,
+            providerUrl: providerUrl,
             api,
           });
 

--- a/packages/cli/src/commands/import-data.ts
+++ b/packages/cli/src/commands/import-data.ts
@@ -22,7 +22,7 @@ export const handler = async (
   argv: Arguments<GlobalOptions>,
 ): Promise<void> => {
   try {
-    const { providerUrl, store, table, file } = argv;
+    const { store, table, file } = argv;
     if (typeof table !== "string") {
       throw new Error("table name parameter is required");
     }
@@ -30,6 +30,10 @@ export const handler = async (
     const apiUrl = helpers.getApiUrl({ apiUrl: argv.apiUrl, store: fileStore });
     const api = helpers.getApi(fileStore, apiUrl);
     const projectId = helpers.getProject({ ...argv, store: fileStore });
+    const providerUrl = helpers.getProviderUrl({
+      providerUrl: argv.providerUrl,
+      store: fileStore,
+    });
 
     const environmentId = await helpers.getEnvironmentId(api, projectId);
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -37,11 +37,16 @@ export const handler = async (
       ? questions.map((q) => q.default)
       : await helpers.ask(questions.map((q) => q.message));
 
-    const fileJson: { privateKey?: string; providerUrl?: string } = {};
+    const fileJson: {
+      privateKey?: string;
+      providerUrl?: string;
+      chain?: string;
+    } = {};
     if (answers[0]) fileJson.privateKey = answers[0];
     if (answers[1]) fileJson.providerUrl = answers[1];
+    if (answers[2]) fileJson.chain = answers[2];
 
-    const configFilePath = getFullConfigPath(answers[2]);
+    const configFilePath = getFullConfigPath(answers[3]);
     if (typeof configFilePath !== "string") {
       throw new Error("invalid config file path");
     }
@@ -67,6 +72,11 @@ const questions = [
   {
     name: "providerUrl",
     message: "Enter a default blockchain provider URL (optional) ",
+    default: undefined,
+  },
+  {
+    name: "chain",
+    message: "Enter a default chain (optional) ",
     default: undefined,
   },
   {

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -17,10 +17,14 @@ export const handler = async (
   argv: Arguments<GlobalOptions>,
 ): Promise<void> => {
   try {
-    const { chain, apiUrl: apiUrlArg, providerUrl, store } = argv;
+    const { chain, apiUrl: apiUrlArg, store } = argv;
     const fileStore = new FileStore(store);
     const apiUrl = helpers.getApiUrl({ apiUrl: apiUrlArg, store: fileStore });
     const api = helpers.getApi(fileStore, apiUrl);
+    const providerUrl = helpers.getProviderUrl({
+      providerUrl: argv.providerUrl,
+      store: fileStore,
+    });
 
     const user = await api.auth.authenticated.query();
     if (user) {

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -24,7 +24,7 @@ export const handler = async (
   argv: Arguments<GlobalOptions>,
 ): Promise<void> => {
   try {
-    const { store, providerUrl } = argv;
+    const { store } = argv;
 
     if (typeof store !== "string" || store.trim() === "") {
       throw new Error("must provide path to session store file");
@@ -34,6 +34,10 @@ export const handler = async (
     const apiUrl = helpers.getApiUrl({ apiUrl: argv.apiUrl, store: fileStore });
     const api = helpers.getApi(fileStore, apiUrl);
     const projectId = helpers.getProject({ ...argv, store: fileStore });
+    const providerUrl = helpers.getProviderUrl({
+      providerUrl: argv.providerUrl,
+      store: fileStore,
+    });
 
     if (typeof projectId !== "string" || !helpers.isUUID(projectId)) {
       throw new Error(ERROR_INVALID_PROJECT_ID);

--- a/packages/cli/src/commands/use.ts
+++ b/packages/cli/src/commands/use.ts
@@ -5,7 +5,7 @@ import { logger, FileStore, helpers } from "../utils.js";
 // note: abnormal spacing is needed to ensure help message is formatted correctly
 export const command = "use [context] [id]";
 export const desc =
-  "use the given context id for all    ensuing commands. context can be one of (team, project, or api). ";
+  "use the given context id for all    ensuing commands. context can be one of (api, chain, team, project, or  provider). ";
 
 export const handler = async (
   argv: Arguments<GlobalOptions>,
@@ -35,13 +35,19 @@ export const handler = async (
         fileStore.set("apiUrl", id);
         fileStore.save();
         break;
+      case "chain":
+        fileStore.set("chain", id);
+        fileStore.save();
+        break;
+      case "provider":
+        fileStore.set("providerUrl", id);
+        fileStore.save();
+        break;
       default:
         throw new Error(`cannot set context for: ${context}`);
     }
 
-    logger.log(
-      `your ${context} context has been set to ${context}_id of: ${id}`,
-    );
+    logger.log(`your ${context} context has been set to: ${id}`);
   } catch (err: any) {
     logger.error(err);
   }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -414,6 +414,16 @@ export const helpers = {
 
     return argv.store.get<string>("projectId");
   },
+  getProviderUrl: function (argv: { store: FileStore; providerUrl: unknown }) {
+    if (
+      typeof argv.providerUrl === "string" &&
+      argv.providerUrl.trim() !== ""
+    ) {
+      return argv.providerUrl.trim();
+    }
+
+    return argv.store.get<string>("providerUrl");
+  },
   getQueryValidator: async function () {
     await init();
     return async function (query: string) {

--- a/packages/cli/test/deployment.test.ts
+++ b/packages/cli/test/deployment.test.ts
@@ -152,6 +152,9 @@ describe("commands/deployment", function () {
         question: async function (qstn: string) {
           message = qstn;
         },
+        close: function () {
+          rlStub.restore();
+        },
       };
     });
 
@@ -173,7 +176,6 @@ describe("commands/deployment", function () {
       .command(mod)
       .parse();
 
-    rlStub.restore();
     const lines = message.split("\n");
 
     equal(

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -74,8 +74,11 @@ describe("commands/init", function () {
         stdin.send("\n");
       }, 1500);
       setTimeout(() => {
-        stdin.send("\n").end();
+        stdin.send("\n");
       }, 2500);
+      setTimeout(() => {
+        stdin.send("\n").end();
+      }, 4500);
 
       // run the command
       await yargs(["init"]).command<GlobalOptions>(mod).parse();
@@ -97,6 +100,7 @@ describe("commands/init", function () {
       const privateKey =
         "0x47c99abed3324a2707c28affff1267e45918ec8c3f20b8aa892e8b065d2942dd";
       const providerUrl = "http://127.0.0.1:8545";
+      const chain = "local-tableland";
       // put the session file in a non default spot
       const sessionPath = path.join("test", "validator");
       // setup user input entry with values
@@ -107,8 +111,11 @@ describe("commands/init", function () {
         stdin.send(`${providerUrl}\n`);
       }, 1500);
       setTimeout(() => {
+        stdin.send(`${chain}\n`);
+      }, 3000);
+      setTimeout(() => {
         stdin.send(`${sessionPath}\n`).end();
-      }, 2500);
+      }, 5000);
 
       // run the command
       await yargs(["init"]).command<GlobalOptions>(mod).parse();
@@ -129,6 +136,7 @@ describe("commands/init", function () {
         privateKey:
           "0x47c99abed3324a2707c28affff1267e45918ec8c3f20b8aa892e8b065d2942dd",
         providerUrl: "http://127.0.0.1:8545",
+        chain: "local-tableland",
       });
     });
   });

--- a/packages/cli/test/use.test.ts
+++ b/packages/cli/test/use.test.ts
@@ -136,11 +136,55 @@ describe("commands/use", function () {
     equal(
       consoleLog.getCall(1).firstArg,
       // typescript linting doesn't honor the assertion of the runtime type here, so we need to cast
-      `your team context has been set to team_id of: ${teamId as string}`,
+      `your team context has been set to: ${teamId as string}`,
     );
 
     const session = getSession();
     equal(session.teamId, teamId);
+  });
+
+  test("use command can set chain", async function () {
+    const chain = "local-tableland";
+    const consoleLog = spy(logger, "log");
+
+    await yargs([
+      "use",
+      "chain",
+      chain,
+      ...defaultArgs,
+      "--privateKey",
+      accounts[10].privateKey.slice(2),
+    ])
+      .command<GlobalOptions>(modUse)
+      .parse();
+
+    equal(
+      consoleLog.getCall(0).firstArg,
+      // typescript linting doesn't honor the assertion of the runtime type here, so we need to cast
+      `your chain context has been set to: ${chain}`,
+    );
+  });
+
+  test("use command can set provider url", async function () {
+    const providerUrl = "http://localhost:8000";
+    const consoleLog = spy(logger, "log");
+
+    await yargs([
+      "use",
+      "provider",
+      providerUrl,
+      ...defaultArgs,
+      "--privateKey",
+      accounts[10].privateKey.slice(2),
+    ])
+      .command<GlobalOptions>(modUse)
+      .parse();
+
+    equal(
+      consoleLog.getCall(0).firstArg,
+      // typescript linting doesn't honor the assertion of the runtime type here, so we need to cast
+      `your provider context has been set to: ${providerUrl}`,
+    );
   });
 
   test("unuse command clears existing context", async function () {


### PR DESCRIPTION
fixes https://linear.app/tableland/issue/STU-197/cli-creating-tables-or-importing-data-doesnt-use-login-context

This PR enables you to `use` "chain" and "provider", as well as adds the option to set a default chain value during the `init` command 