### PR TITLE
(web) fix error message overflow issue in deploy modal

### DIFF
--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -101,7 +101,6 @@ describe("commands/status", function () {
 
     equal(user.user.address, "0xBcd4042DE499D14e55001CcbB24a551F3b954096");
     equal(user.user.teamId, TEST_TEAM_ID);
-    equal(user.user.email, "testuser@textile.io");
     equal(user.personalTeam.id, TEST_TEAM_ID);
     equal(user.personalTeam.name, "testuser");
     equal(user.personalTeam.slug, "testuser");

--- a/packages/web/app/[team]/[project]/(project)/deployments/[[...slug]]/_components/exec-deployment.tsx
+++ b/packages/web/app/[team]/[project]/(project)/deployments/[[...slug]]/_components/exec-deployment.tsx
@@ -191,74 +191,67 @@ export default function ExecDeployment({
 
   return (
     <Dialog open={showDialog} onOpenChange={handleOnOpenChange}>
-      <DialogContent>
-        <div className="flex flex-auto flex-col gap-y-4 overflow-auto">
-          <DialogHeader>
-            <DialogTitle>Deploy Table: {table.name}</DialogTitle>
-            <DialogDescription>
-              Deploying a Table to Tableland will require you to sign and send a
-              transaction, as well as pay any transaction fees. Once the Table
-              has been deployed, it will be registered with your Studio Project
-              and you&apos;ll be able to view it in the Deployments tab.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex items-center gap-2">
-            <Label>Deploy to</Label>
-            <ChainSelector
-              onValueChange={setChainId}
-              disabled={pendingDeploy}
-            />
-          </div>
-          <DeployStep
-            pendingText="Resolve signer"
-            processingText="Resolving signer..."
-            completeText="Signer resolved"
-            state={signerState}
-          />
-          <DeployStep
-            pendingText="Wait for transaction"
-            processingText="Waiting for transaction..."
-            completeText="Transaction complete"
-            state={txnState}
-          />
-          <DeployStep
-            pendingText="Confirmation from the Tableland network"
-            processingText="Getting confirmation from the Tableland network..."
-            completeText="Tableland network confirmation received"
-            state={tblReceiptState}
-          />
-          <DeployStep
-            pendingText="Register Deployment with Studio"
-            processingText="Registering Deployment with Studio..."
-            completeText="Deployment registered with Studio"
-            state={recordDeploymentState}
-          />
+      <DialogContent className="flex flex-auto flex-col gap-y-4 overflow-auto">
+        <DialogHeader>
+          <DialogTitle>Deploy Table: {table.name}</DialogTitle>
           <DialogDescription>
-            <span className="font-semibold text-foreground">Important:</span>{" "}
-            Don&apos;t close or navigate away from this dialog while the
-            Deployment is executing. If you do, or if you cancel, you&apos;ll
-            likely still pay transaction fees and your table will still be
-            created on Tableland, but not be registered with Studio.
+            Deploying a Table to Tableland will require you to sign and send a
+            transaction, as well as pay any transaction fees. Once the Table has
+            been deployed, it will be registered with your Studio Project and
+            you&apos;ll be able to view it in the Deployments tab.
           </DialogDescription>
-          <DialogFooter>
-            <Button variant="outline" onClick={handleCancel}>
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              // TODO: `handleSubmit` creates a floating promise, as a result the linter is complaining
-              //    we should figure out if this is ok or not and either change this or the lint config
-              // eslint-disable-next-line @typescript-eslint/no-misused-promises
-              onClick={handleDeploy}
-              disabled={pendingDeploy || !chainId}
-            >
-              {pendingDeploy && (
-                <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-              )}
-              Deploy
-            </Button>
-          </DialogFooter>
+        </DialogHeader>
+        <div className="flex items-center gap-2">
+          <Label>Deploy to</Label>
+          <ChainSelector onValueChange={setChainId} disabled={pendingDeploy} />
         </div>
+        <DeployStep
+          pendingText="Resolve signer"
+          processingText="Resolving signer..."
+          completeText="Signer resolved"
+          state={signerState}
+        />
+        <DeployStep
+          pendingText="Wait for transaction"
+          processingText="Waiting for transaction..."
+          completeText="Transaction complete"
+          state={txnState}
+        />
+        <DeployStep
+          pendingText="Confirmation from the Tableland network"
+          processingText="Getting confirmation from the Tableland network..."
+          completeText="Tableland network confirmation received"
+          state={tblReceiptState}
+        />
+        <DeployStep
+          pendingText="Register Deployment with Studio"
+          processingText="Registering Deployment with Studio..."
+          completeText="Deployment registered with Studio"
+          state={recordDeploymentState}
+        />
+        <DialogDescription>
+          <span className="font-semibold text-foreground">Important:</span>{" "}
+          Don&apos;t close or navigate away from this dialog while the
+          Deployment is executing. If you do, or if you cancel, you&apos;ll
+          likely still pay transaction fees and your table will still be created
+          on Tableland, but not be registered with Studio.
+        </DialogDescription>
+        <DialogFooter>
+          <Button variant="outline" onClick={handleCancel}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            // TODO: `handleSubmit` creates a floating promise, as a result the linter is complaining
+            //    we should figure out if this is ok or not and either change this or the lint config
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
+            onClick={handleDeploy}
+            disabled={pendingDeploy || !chainId}
+          >
+            {pendingDeploy && <Loader2 className="mr-2 h-5 w-5 animate-spin" />}
+            Deploy
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
fixes: https://linear.app/tableland/issue/STU-215/deploy-modal-overflow-issue

See the above linear issue for an example of the broken layout that occurs when a transaction is rejected.

To see the new behavior:
- start the web app 
- create a prject and a table
- start to deploy the table
- when your wallet prompt asks permission, reject the request