### PR TITLE
(cli) add status command to show current session values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22205,7 +22205,7 @@
     },
     "packages/cli": {
       "name": "@tableland/studio-cli",
-      "version": "0.0.0-pre.9",
+      "version": "0.0.0-pre.10",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@tableland/sdk": "^5.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/studio-cli",
-  "version": "0.0.0-pre.9",
+  "version": "0.0.0-pre.10",
   "description": "Tableland command line tools",
   "repository": "https://github.com/tablelandnetwork/studio/cli",
   "publishConfig": {

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -6,20 +6,22 @@ import * as login from "./login.js";
 import * as logout from "./logout.js";
 import * as project from "./project.js";
 import * as query from "./query.js";
+import * as status from "./status.js";
 import * as team from "./team.js";
 import * as use from "./use.js";
 import * as unuse from "./unuse.js";
 
 export const commands = [
+  deployment,
+  init,
+  importData,
+  importTable,
   login,
   logout,
-  team,
-  init,
   project,
-  deployment,
-  importData,
   query,
-  importTable,
+  status,
+  team,
   use,
   unuse,
 ];

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,0 +1,38 @@
+import type { Arguments } from "yargs";
+import { type GlobalOptions } from "../cli.js";
+import { logger, FileStore, helpers } from "../utils.js";
+
+export const command = "status";
+export const desc = "show the status of the current session";
+
+export const handler = async (
+  argv: Arguments<GlobalOptions>,
+): Promise<void> => {
+  try {
+    const { store } = argv;
+
+    const fileStore = new FileStore(store);
+    const apiUrl = helpers.getApiUrl({ apiUrl: argv.apiUrl, store: fileStore });
+    const api = helpers.getApi(fileStore, apiUrl);
+
+    const user = await api.auth.authenticated.query();
+    if (!user) {
+      logger.log("not logged in");
+      return;
+    }
+
+    const notSet = "undefined";
+    logger.log(
+      `logged in as: ${JSON.stringify(user, null, 4)}
+context: ${JSON.stringify({
+        team: fileStore.get("teamId") ?? notSet,
+        project: fileStore.get("projectId") ?? notSet,
+        api: fileStore.get("apiUrl") ?? notSet,
+        chain: fileStore.get("chain") ?? notSet,
+        provider: fileStore.get("providerUrl") ?? argv.providerUrl ?? notSet,
+      })}`,
+    );
+  } catch (err: any) {
+    logger.error(err);
+  }
+};

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -1,0 +1,121 @@
+import path from "path";
+import { fileURLToPath } from "url";
+import { equal } from "assert";
+import { getAccounts } from "@tableland/local";
+import { afterEach, before, describe, test } from "mocha";
+import { restore, spy } from "sinon";
+import yargs from "yargs/yargs";
+import { type GlobalOptions } from "../src/cli.js";
+import * as modUse from "../src/commands/use.js";
+import * as modStatus from "../src/commands/status.js";
+import * as modLogin from "../src/commands/login.js";
+import * as modLogout from "../src/commands/logout.js";
+import { logger, wait } from "../src/utils.js";
+import {
+  TEST_API_BASE_URL,
+  TEST_PROJECT_ID,
+  TEST_REGISTRY_PORT,
+  TEST_TEAM_ID,
+  TEST_TIMEOUT_FACTOR,
+} from "./utils";
+
+const _dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const sessionFilePath = path.join(_dirname, ".studioclisession.json");
+const accounts = getAccounts();
+const defaultArgs = [
+  "--store",
+  sessionFilePath,
+  "--chain",
+  "local-tableland",
+  "--providerUrl",
+  `http://127.0.0.1:${TEST_REGISTRY_PORT}/`,
+  "--apiUrl",
+  TEST_API_BASE_URL,
+];
+
+describe("commands/status", function () {
+  this.timeout(30000 * TEST_TIMEOUT_FACTOR);
+
+  before(async function () {
+    await wait(1000);
+
+    await yargs([
+      "logout",
+      ...defaultArgs,
+      "--privateKey",
+      accounts[10].privateKey.slice(2),
+    ])
+      .command<GlobalOptions>(modLogout)
+      .parse();
+  });
+
+  beforeEach(async function () {
+    await yargs([
+      "login",
+      ...defaultArgs,
+      "--privateKey",
+      accounts[10].privateKey.slice(2),
+    ])
+      .command<GlobalOptions>(modLogin)
+      .parse();
+  });
+
+  afterEach(async function () {
+    restore();
+
+    await yargs([
+      "logout",
+      ...defaultArgs,
+      "--privateKey",
+      accounts[10].privateKey.slice(2),
+    ])
+      .command<GlobalOptions>(modLogout)
+      .parse();
+  });
+
+  test("status command can list session status", async function () {
+    await yargs(["use", "team", TEST_TEAM_ID, ...defaultArgs])
+      .command<GlobalOptions>(modUse)
+      .parse();
+
+    await yargs(["use", "project", TEST_PROJECT_ID, ...defaultArgs])
+      .command<GlobalOptions>(modUse)
+      .parse();
+
+    const consoleLog = spy(logger, "log");
+
+    await yargs(["status", ...defaultArgs])
+      .command<GlobalOptions>(modStatus)
+      .parse();
+
+    const res = consoleLog.getCall(0).firstArg;
+    equal(res.startsWith("logged in as: {"), true);
+
+    const user = JSON.parse(
+      res
+        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+        .slice(res.indexOf("logged in as: ") + 14, res.indexOf("context: "))
+        .replace(/\n/g, ""),
+    );
+
+    equal(user.user.address, "0xBcd4042DE499D14e55001CcbB24a551F3b954096");
+    equal(user.user.teamId, TEST_TEAM_ID);
+    equal(user.user.email, "testuser@textile.io");
+    equal(user.personalTeam.id, TEST_TEAM_ID);
+    equal(user.personalTeam.name, "testuser");
+    equal(user.personalTeam.slug, "testuser");
+    equal(user.personalTeam.personal, 1);
+
+    const context = JSON.parse(
+      // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+      res.slice(res.indexOf("context: ") + 9).replace(/\n/g, ""),
+    );
+
+    equal(context.team, "a3cd7fac-4528-4765-9ae1-304460555429");
+    equal(context.project, "2f403473-de7b-41ba-8d97-12a0344aeccb");
+    equal(context.api, "http://localhost:2999");
+    equal(context.chain, "undefined");
+    equal(context.provider, "http://127.0.0.1:8546/");
+  });
+});

--- a/packages/cli/test/team.test.ts
+++ b/packages/cli/test/team.test.ts
@@ -5,7 +5,10 @@ import { getAccounts } from "@tableland/local";
 import { afterEach, before, describe, test } from "mocha";
 import { restore, spy, stub } from "sinon";
 import yargs from "yargs/yargs";
+import { type GlobalOptions } from "../src/cli.js";
 import * as mod from "../src/commands/team.js";
+import * as modLogin from "../src/commands/login.js";
+import * as modLogout from "../src/commands/logout.js";
 import { type FileStore, logger, wait, helpers } from "../src/utils.js";
 import {
   TEST_TIMEOUT_FACTOR,
@@ -35,10 +38,24 @@ describe("commands/team", function () {
 
   before(async function () {
     await wait(1000);
+
+    await yargs(["logout", ...defaultArgs])
+      .command<GlobalOptions>(modLogout)
+      .parse();
   });
 
-  afterEach(function () {
+  beforeEach(async function () {
+    await yargs(["login", ...defaultArgs])
+      .command<GlobalOptions>(modLogin)
+      .parse();
+  });
+
+  afterEach(async function () {
     restore();
+
+    await yargs(["logout", ...defaultArgs])
+      .command<GlobalOptions>(modLogout)
+      .parse();
   });
 
   // TODO: all the tests depend on previous tests, need to fix this


### PR DESCRIPTION
**NOTE: This is RFR but needs to wait until after #178 is resolved**

## Overview

The CLI user's current login session context and wallet contains quite a bit of information which will become more difficult to keep track of as more properties are available in the context.  The PR introduces a `status` command which prints the user's wallet address and the current context values, e.g. project, team, chain, etc...

## Details

At any point you can run `npx studio status` and you'll see and output similar to the example below:
```
logged in as: {
    "user": {
        "address": "0xd535bAd504CDd77e2C51dE26F416693DF7a01ac8",
        "teamId": "0fc35500-1b1f-41ff-bb1c-0b581f91c843"
    },
    "personalTeam": {
        "id": "0fc35500-1b1f-41ff-bb1c-0b581f91c843",
        "name": "joe",
        "slug": "joe",
        "personal": 1
    }
}
context: {
  team: undefined,
  project: undefined,
  api: https://studio.tableland.xyz,
  chain: undefined,
  provider: http://127.0.0.1:8545
}
```

closes https://linear.app/tableland/issue/ENG-557/cli-add-a-status-command-that-shows-the-state-of-a-user-config