### PR TITLE
(cli) query command refactored

### DIFF
--- a/packages/cli/test/deployment.test.ts
+++ b/packages/cli/test/deployment.test.ts
@@ -75,7 +75,7 @@ describe("commands/deployment", function () {
       // actually create a deployment on maticmum.
       stdin.send("n\n").end();
       stdin.restore();
-    }, 3500);
+    }, 5000);
 
     await yargs([
       "deployment",


### PR DESCRIPTION
## Overview

The `query` command had devolved into being hard to read and reason about.  This PR does not change any functionality, it only refactors the command logic into a class.

## Details

I've refactored a singular command handler function into a class.  This makes it easier to read through, replaces variable mutation with instance properties, allows caching tableland Database instances, etc...

resolves https://linear.app/tableland/issue/ENG-556/query-command-needs-code-to-be-refactored-and-made-more-readable
