### PR TITLE
(cli) better error messaging, and nicer status message format

### DIFF
--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -24,13 +24,17 @@ export const handler = async (
     const notSet = "undefined";
     logger.log(
       `logged in as: ${JSON.stringify(user, null, 4)}
-context: ${JSON.stringify({
-        team: fileStore.get("teamId") ?? notSet,
-        project: fileStore.get("projectId") ?? notSet,
-        api: fileStore.get("apiUrl") ?? notSet,
-        chain: fileStore.get("chain") ?? notSet,
-        provider: fileStore.get("providerUrl") ?? argv.providerUrl ?? notSet,
-      })}`,
+context: ${JSON.stringify(
+        {
+          team: fileStore.get("teamId") ?? notSet,
+          project: fileStore.get("projectId") ?? notSet,
+          api: fileStore.get("apiUrl") ?? notSet,
+          chain: fileStore.get("chain") ?? notSet,
+          provider: fileStore.get("providerUrl") ?? argv.providerUrl ?? notSet,
+        },
+        null,
+        4,
+      )}`,
     );
   } catch (err: any) {
     logger.error(err);

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -450,8 +450,10 @@ export const helpers = {
     providerUrl,
     api,
   }: Options): Promise<Wallet> {
-    if (privateKey == null) {
-      throw new Error("missing required flag (`-k` or `--privateKey`)");
+    if (privateKey == null || privateKey?.trim() === "") {
+      throw new Error(
+        "missing required private key (use `.tablelandrc.json` file, or include `-k` or `--privateKey` flag)",
+      );
     }
     let network: sdkHelpers.ChainInfo;
     try {

--- a/packages/cli/test/deployment.test.ts
+++ b/packages/cli/test/deployment.test.ts
@@ -75,7 +75,7 @@ describe("commands/deployment", function () {
       // actually create a deployment on maticmum.
       stdin.send("n\n").end();
       stdin.restore();
-    }, 5000);
+    }, 7000);
 
     await yargs([
       "deployment",


### PR DESCRIPTION
## Overview 
The commands that require a private key were checking for `null` but not checking for the empty string.  This result in an unhelpful error message when a private key is not provided.  This PR fixes that issue and includes a change to make the output of `status` easier to read.

## Details
The status message output is a mixture of text and json, and some of the json was not being pretty printed.  
The check for a required private key was ensuring the value is not null and not undefined.  We also needed to check for an empty string.

fixes https://linear.app/tableland/issue/ENG-558/cli-when-config-isnt-sufficient-the-resulting-error-messages-are