### PR TITLE
(web) redirect to home after logout

### DIFF
--- a/packages/web/components/profile.tsx
+++ b/packages/web/components/profile.tsx
@@ -43,7 +43,7 @@ export default function Profile({
   const logout = api.auth.logout.useMutation({
     onSuccess: () => {
       setAuth(undefined);
-      router.refresh();
+      router.push("/");
     },
   });
   const [signInError, setSignInError] = useState<Error | undefined>(undefined);


### PR DESCRIPTION
A simple change here.
fixes https://linear.app/tableland/issue/ENG-537/redirect-to-home-page-on-logout
I also noticed that there may have been a duplicate issue in linear.
this also fixes https://linear.app/tableland/issue/ENG-538/web-if-i-logout-the-page-doesnt-change