### PR TITLE
(web) make hotjar script load beforeInteractive

### DIFF
--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -72,6 +72,7 @@ export default async function RootLayout({
         >
           <Script
             id="hotjar"
+            strategy="beforeInteractive"
             dangerouslySetInnerHTML={{
               __html: `(function(h,o,t,j,a,r){ h.hj=h.hjfunction(){(h.hj.q=h.hj.q[]).push(arguments)}; h._hjSettings={hjid:3842183,hjsv:6}; a=o.getElementsByTagName('head')[0]; r=o.createElement('script');r.async=1; r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv; a.appendChild(r); })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');`,
             }}


### PR DESCRIPTION
Looks like the hotjar script wasn't working.  Hotjar instructions ask that the script tag be put in the `head` html element, but next.js does not allow doing that without adding some third party packages.  In this PR I'm trying to get hotjar to load using the next `Script` component's [beforeInteractive strategy](https://nextjs.org/docs/pages/api-reference/components/script#beforeinteractive).