### PR TITLE
(store,web) use dist files for migration script

### DIFF
--- a/packages/store/src/schema/index.ts
+++ b/packages/store/src/schema/index.ts
@@ -6,7 +6,7 @@ import {
   text,
   uniqueIndex,
 } from "drizzle-orm/sqlite-core";
-import { schema } from "../custom-types/index";
+import { schema } from "../custom-types/index.js";
 
 export const users = sqliteTable(
   "users",

--- a/packages/web/drizzle.config.ts
+++ b/packages/web/drizzle.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "drizzle-kit";
 
 export default {
-  schema: "../store/src/schema/index.ts",
+  schema: "../store/dist/schema/index.js",
   driver: "better-sqlite",
   out: "./drizzle",
 } satisfies Config;


### PR DESCRIPTION
In order to meet the requirements of some packages being released on npm for use with cjs, esm, ts, and also allow running the Drizzle migration scripts we need to use `.js` file extensions and the `dist` directory uris when `import'ing files in the Drizzle scripts.