### PR TITLE
Use MetricCard in TablelandTable component

### DIFF
--- a/packages/web/app/[team]/(team)/people/page.tsx
+++ b/packages/web/app/[team]/(team)/people/page.tsx
@@ -5,7 +5,7 @@ import Info from "./_components/info";
 import InviteActions from "./_components/invite-actions";
 import NewInvite from "./_components/new-invite";
 import UserActions from "./_components/user-actions";
-import AddressDisplay from "@/components/address-display";
+import HashDisplay from "@/components/hash-display";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/server";
@@ -79,8 +79,8 @@ export default async function People({ params }: { params: { team: string } }) {
                   {person.personalTeam.name}
                   {person.personalTeam.id === auth?.personalTeam.id && " (You)"}
                 </p>
-                <AddressDisplay
-                  address={person.address}
+                <HashDisplay
+                  hash={person.address}
                   copy={true}
                   numCharacters={7}
                 />

--- a/packages/web/app/sql-log/page.tsx
+++ b/packages/web/app/sql-log/page.tsx
@@ -10,7 +10,7 @@ import {
   MetricCardHeader,
   MetricCardTitle,
 } from "@/components/metric-card";
-import AddressDisplay from "@/components/address-display";
+import HashDisplay from "@/components/hash-display";
 import { chainsMap } from "@/lib/chains-map";
 import { cn } from "@/lib/utils";
 import { getSqlLog } from "@/lib/validator-queries";
@@ -58,8 +58,8 @@ export default async function TxnPage({
           </TooltipProvider>
         )}
         <div className="flex flex-col">
-          <AddressDisplay
-            address={log.txHash}
+          <HashDisplay
+            hash={log.txHash}
             name="txn hash"
             numCharacters={8}
             copy
@@ -86,8 +86,8 @@ export default async function TxnPage({
             <MetricCardTitle>Sent by</MetricCardTitle>
           </MetricCardHeader>
           <MetricCardContent>
-            <AddressDisplay
-              address={log.caller}
+            <HashDisplay
+              hash={log.caller}
               copy
               className="text-3xl text-foreground"
             />

--- a/packages/web/components/hash-display.tsx
+++ b/packages/web/components/hash-display.tsx
@@ -12,17 +12,18 @@ import {
 import { useToast } from "@/components/ui/use-toast";
 import { cn } from "@/lib/utils";
 
-export default function AddressDisplay({
-  address,
+export default function HashDisplay({
+  hash,
   numCharacters = 5,
   copy = false,
-  name,
+  hashDesc = "address",
   className,
   ...rest
 }: HTMLProps<HTMLSpanElement> & {
-  address: string;
+  hash: string;
   numCharacters?: number;
   copy?: boolean;
+  hashDesc?: string;
 }) {
   const { toast } = useToast();
 
@@ -31,19 +32,17 @@ export default function AddressDisplay({
     //    needed here, but some kind lock of the UI when async ops are happening
     //    could make the ui feel more responsive.
     navigator.clipboard
-      .writeText(address)
+      .writeText(hash)
       .then(function () {
         toast({
           title: "Done!",
-          description: `The ${
-            name ?? "address"
-          } has been copied to your clipboard.`,
+          description: `The ${hashDesc} has been copied to your clipboard.`,
           duration: 2000,
         });
       })
       .catch(function (err) {
         const errMessage = [
-          `Could not copy the ${name ?? "address"} to your clipboard.`,
+          `Could not copy the ${hashDesc} to your clipboard.`,
           typeof err.message === "string" ? err.message : undefined,
         ]
           .filter((s) => s)
@@ -66,12 +65,12 @@ export default function AddressDisplay({
               className={cn("text-sm text-muted-foreground", className)}
               {...rest}
             >
-              {address.slice(0, numCharacters)}...
-              {address.slice(-numCharacters)}
+              {hash.slice(0, numCharacters)}...
+              {hash.slice(-numCharacters)}
             </span>
           </TooltipTrigger>
           <TooltipContent>
-            <p>{address}</p>
+            <p>{hash}</p>
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
@@ -85,11 +84,11 @@ export default function AddressDisplay({
                 onClick={handleCopy}
               >
                 <Copy className="h-4 w-4 stroke-slate-300" />
-                <span className="sr-only">Copy {name ?? "address"}</span>
+                <span className="sr-only">Copy {hashDesc}</span>
               </Button>
             </TooltipTrigger>
             <TooltipContent>
-              <p>Click to copy {name ?? "address"}</p>
+              <p>Click to copy {hashDesc}</p>
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/packages/web/components/metric-card.tsx
+++ b/packages/web/components/metric-card.tsx
@@ -71,7 +71,9 @@ const MetricCardContent = React.forwardRef<
       {tooltipText ? (
         <TooltipProvider>
           <Tooltip>
-            <TooltipTrigger>{children}</TooltipTrigger>
+            <TooltipTrigger className="tracking-tight">
+              {children}
+            </TooltipTrigger>
             <TooltipContent>{tooltipText}</TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/packages/web/components/profile.tsx
+++ b/packages/web/components/profile.tsx
@@ -6,7 +6,7 @@ import { LogOut } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useAccount, useConnect } from "wagmi";
-import AddressDisplay from "./address-display";
+import HashDisplay from "./hash-display";
 import RegistrationDialog from "./registration-dialog";
 import SignInButton from "./sign-in-button";
 import { Button } from "./ui/button";
@@ -127,7 +127,7 @@ export default function Profile({
       {isConnected && (
         <>
           {/* Wallet content goes here */}
-          {address && !hideAddress && <AddressDisplay address={address} copy />}
+          {address && !hideAddress && <HashDisplay hash={address} copy />}
           {auth ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/packages/web/components/tableland-table.tsx
+++ b/packages/web/components/tableland-table.tsx
@@ -5,11 +5,19 @@ import TimeAgo from "javascript-time-ago";
 import { Blocks, Coins, Hash, Rocket, Table2 } from "lucide-react";
 import Link from "next/link";
 import { DataTable } from "../app/[team]/[project]/(project)/deployments/[[...slug]]/_components/data-table";
-import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import {
+  MetricCard,
+  MetricCardContent,
+  MetricCardFooter,
+  MetricCardHeader,
+  MetricCardTitle,
+} from "./metric-card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 import SQLLogs from "./sql-logs";
+import HashDisplay from "./hash-display";
 import { blockExplorers } from "@/lib/block-explorers";
 import { openSeaLinks } from "@/lib/open-sea";
+import { chainsMap } from "@/lib/chains-map";
 
 const timeAgo = new TimeAgo("en-US");
 
@@ -49,7 +57,7 @@ export default async function TablelandTable({
   tableData,
   deploymentData,
 }: Props) {
-  const chainInfo = helpers.getChainInfo(chainId);
+  const chain = chainsMap.get(chainId);
   const blockExplorer = blockExplorers.get(chainId);
   const openSeaLink = openSeaLinks.get(chainId);
 
@@ -80,101 +88,86 @@ export default async function TablelandTable({
         </Select> */}
       </div>
       <div className="grid grid-flow-row grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Deployed to</CardTitle>
+        <MetricCard>
+          <MetricCardHeader className="flex flex-row items-center gap-2 space-y-0">
             <Rocket className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-semibold">{chainInfo.chainName}</div>
-            <p className="text-xs text-muted-foreground">
-              {timeAgo.format(createdAt)}
-            </p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              Tableland Table
-            </CardTitle>
+            <MetricCardTitle>Deployed to</MetricCardTitle>
+          </MetricCardHeader>
+          <MetricCardContent>{chain?.name}</MetricCardContent>
+          <MetricCardFooter>{timeAgo.format(createdAt)}</MetricCardFooter>
+        </MetricCard>
+        <MetricCard>
+          <MetricCardHeader className="flex flex-row items-center gap-2 space-y-0">
             <Table2 className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-semibold">{tableName}</div>
-            <Link
-              className="text-xs text-muted-foreground"
-              href={`https://tablescan.io/${tableName}`}
-            >
+            <MetricCardTitle>Tableland Table</MetricCardTitle>
+          </MetricCardHeader>
+          <MetricCardContent tooltipText={tableName}>
+            {tableName}
+          </MetricCardContent>
+          <MetricCardFooter>
+            <Link href={`https://tablescan.io/${tableName}`}>
               View on Tablescan
             </Link>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Token ID</CardTitle>
+          </MetricCardFooter>
+        </MetricCard>
+        <MetricCard>
+          <MetricCardHeader className="flex flex-row items-center gap-2 space-y-0">
             <Coins className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-semibold">{tokenId}</div>
-            {openSeaLink && (
-              <Link
-                target="_blank"
-                href={openSeaLink.tokenUrl(tokenId)}
-                className="text-xs text-muted-foreground"
-              >
+            <MetricCardTitle>Token ID</MetricCardTitle>
+          </MetricCardHeader>
+          <MetricCardContent>{tokenId}</MetricCardContent>
+          {openSeaLink && (
+            <MetricCardFooter>
+              <Link target="_blank" href={openSeaLink.tokenUrl(tokenId)}>
                 View on OpenSea
               </Link>
-            )}
-          </CardContent>
-        </Card>
+            </MetricCardFooter>
+          )}
+        </MetricCard>
         {deploymentData?.txnHash && (
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">
-                Transaction Hash
-              </CardTitle>
+          <MetricCard>
+            <MetricCardHeader className="flex flex-row items-center gap-2 space-y-0">
               <Hash className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-semibold">
-                {deploymentData.txnHash.slice(0, 5)}...
-                {deploymentData.txnHash.slice(-5)}
-              </div>
-              {blockExplorer && (
+              <MetricCardTitle>Transaction Hash</MetricCardTitle>
+            </MetricCardHeader>
+            <MetricCardContent>
+              <HashDisplay
+                hash={deploymentData.txnHash}
+                copy
+                className="text-3xl text-foreground"
+                hashDesc="txn hash"
+              />
+            </MetricCardContent>
+            {blockExplorer && (
+              <MetricCardFooter>
                 <Link
                   target="_blank"
                   href={blockExplorer.txUrl(deploymentData.txnHash)}
-                  className="text-xs text-muted-foreground"
                 >
                   View on {blockExplorer.explorer}
                 </Link>
-              )}
-            </CardContent>
-          </Card>
+              </MetricCardFooter>
+            )}
+          </MetricCard>
         )}
         {deploymentData?.blockNumber && (
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">
-                Block Number
-              </CardTitle>
+          <MetricCard>
+            <MetricCardHeader className="flex flex-row items-center gap-2 space-y-0">
               <Blocks className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-semibold">
-                {deploymentData.blockNumber}
-              </div>
-              {blockExplorer && (
+              <MetricCardTitle>Block Number</MetricCardTitle>
+            </MetricCardHeader>
+            <MetricCardContent>{deploymentData.blockNumber}</MetricCardContent>
+            {blockExplorer && (
+              <MetricCardFooter>
                 <Link
                   target="_blank"
                   href={blockExplorer.blockUrl(deploymentData.blockNumber)}
-                  className="text-xs text-muted-foreground"
                 >
                   View on {blockExplorer.explorer}
                 </Link>
-              )}
-            </CardContent>
-          </Card>
+              </MetricCardFooter>
+            )}
+          </MetricCard>
         )}
       </div>
       <Tabs defaultValue="data" className="py-4">


### PR DESCRIPTION
Now our use of cards is consistent everywhere. This results in fixing the display issue with long table names in the card. The fix is pretty good, but still not ideal. It's a tricky one. The solution in `MetricCard` uses `hyphen-auto` combined with a tooltip:
![Screenshot 2024-03-06 at 2 18 38 PM](https://github.com/tablelandnetwork/studio/assets/528969/861426e6-c0ea-4f12-844d-82fa7e411b56)
