### PR TITLE
(web) fix invite email input padding

### DIFF
--- a/packages/web/components/tag-input.tsx
+++ b/packages/web/components/tag-input.tsx
@@ -66,7 +66,7 @@ const TagInput = forwardRef<HTMLDivElement, Props>(
       <div
         id={id}
         ref={ref}
-        className="flex w-full max-w-full flex-wrap space-x-1 overflow-scroll rounded-md border pl-1 focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2"
+        className="flex w-full max-w-full flex-wrap space-x-1 rounded-md border pl-1 focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2"
       >
         {tags.map((tag, i) => (
           <div


### PR DESCRIPTION
fixes: https://linear.app/tableland/issue/ENG-818/create-team-email-invite-input-looks-strange

It looks like the additional padding was the existence of non-functional scroll bars.  The content doesn't scroll, so I'm assuming the `overflow-scroll` class is leftover from an older version of the tag input.