### PR TITLE
configure client wagmi provider with api keys

### DIFF
--- a/packages/cli/.env.example
+++ b/packages/cli/.env.example
@@ -6,5 +6,5 @@ SESSION_COOKIE_NAME="STUDIO_SESSION"
 SESSION_COOKIE_PASS="secure password secure password secure password secure password secure password secure password secure password"
 DATA_SEAL_PASS="secure password secure password secure password secure password secure password secure password secure password"
 POSTMARK_API_KEY=fillme(optional)
-API_ROUTER_INFURA_KEY="api key"
-API_ROUTER_QUICK_NODE_KEY="api key"
+NEXT_PUBLIC_API_ROUTER_INFURA_KEY="api key"
+NEXT_PUBLIC_API_ROUTER_QUICK_NODE_KEY="api key"

--- a/packages/web/components/wagmi-provider.tsx
+++ b/packages/web/components/wagmi-provider.tsx
@@ -8,6 +8,10 @@ const { chains, publicClient, webSocketPublicClient } = configuredChains(
   typeof window !== "undefined" &&
     (window.location?.hostname === "localhost" ||
       window.location?.hostname === "127.0.0.1"),
+  {
+    infura: process.env.NEXT_PUBLIC_API_ROUTER_INFURA_KEY ?? "",
+    quickNode: process.env.NEXT_PUBLIC_API_ROUTER_QUICK_NODE_KEY ?? "",
+  },
 );
 
 const config = createConfig({

--- a/packages/web/lib/api-router.ts
+++ b/packages/web/lib/api-router.ts
@@ -11,6 +11,6 @@ export const apiRouter = appRouter(
   (seal) => `${baseUrl}/invite?seal=${seal}`,
   process.env.DATA_SEAL_PASS!,
   process.env.NODE_ENV === "development",
-  process.env.API_ROUTER_INFURA_KEY ?? "",
-  process.env.API_ROUTER_QUICK_NODE_KEY ?? "",
+  process.env.NEXT_PUBLIC_API_ROUTER_INFURA_KEY ?? "",
+  process.env.NEXT_PUBLIC_API_ROUTER_QUICK_NODE_KEY ?? "",
 );


### PR DESCRIPTION
Can't believe I'm changing my analysis of this again, but turns out the client does indeed need the provider API keys and that when the user deploys a table via the wagmi provider, the ETH provider does come from wagmi and this means that wagmi does need to be configured with API keys. Really final answer now.