### PR TITLE
(web) update to layout of metric card, and enable click to copy

### DIFF
--- a/packages/web/components/hash-display.tsx
+++ b/packages/web/components/hash-display.tsx
@@ -10,7 +10,7 @@ import {
   TooltipTrigger,
 } from "./ui/tooltip";
 import { useToast } from "@/components/ui/use-toast";
-import { cn } from "@/lib/utils";
+import { cn, handleCopy } from "@/lib/utils";
 
 export default function HashDisplay({
   hash,
@@ -26,35 +26,6 @@ export default function HashDisplay({
   hashDesc?: string;
 }) {
   const { toast } = useToast();
-
-  const handleCopy = () => {
-    // TODO: clickboard write text is probably really fast, so it might not be
-    //    needed here, but some kind lock of the UI when async ops are happening
-    //    could make the ui feel more responsive.
-    navigator.clipboard
-      .writeText(hash)
-      .then(function () {
-        toast({
-          title: "Done!",
-          description: `The ${hashDesc} has been copied to your clipboard.`,
-          duration: 2000,
-        });
-      })
-      .catch(function (err) {
-        const errMessage = [
-          `Could not copy the ${hashDesc} to your clipboard.`,
-          typeof err.message === "string" ? err.message : undefined,
-        ]
-          .filter((s) => s)
-          .join(" ");
-
-        toast({
-          title: "Error!",
-          description: errMessage,
-          duration: 2000,
-        });
-      });
-  };
 
   return (
     <div>
@@ -81,7 +52,7 @@ export default function HashDisplay({
               <Button
                 variant={"ghost"}
                 className="ml-1 h-auto p-1"
-                onClick={handleCopy}
+                onClick={() => handleCopy(hash, toast)}
               >
                 <Copy className="h-4 w-4 stroke-slate-300" />
                 <span className="sr-only">Copy {hashDesc}</span>

--- a/packages/web/components/hash-display.tsx
+++ b/packages/web/components/hash-display.tsx
@@ -52,7 +52,7 @@ export default function HashDisplay({
               <Button
                 variant={"ghost"}
                 className="ml-1 h-auto p-1"
-                onClick={() => handleCopy(hash, toast)}
+                onClick={() => handleCopy(hash, hashDesc, toast)}
               >
                 <Copy className="h-4 w-4 stroke-slate-300" />
                 <span className="sr-only">Copy {hashDesc}</span>

--- a/packages/web/components/metric-card.tsx
+++ b/packages/web/components/metric-card.tsx
@@ -31,12 +31,46 @@ const MetricCard = React.forwardRef<
 ));
 MetricCard.displayName = "MetricCard";
 
-const MetricCardHeader = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <CardHeader ref={ref} className={cn(className)} {...props} />
-));
+type HeaderMainProps = React.HTMLAttributes<HTMLDivElement>;
+interface HeaderCopyProps {
+  copyValue: string;
+  valueDesc: string;
+  tooltipText: string;
+}
+interface HeaderNoCopyProps {
+  copyValue?: undefined;
+  valueDesc?: never;
+  tooltipText?: never;
+}
+type HeaderProps = HeaderMainProps & (HeaderCopyProps | HeaderNoCopyProps);
+
+const MetricCardHeader = React.forwardRef<HTMLDivElement, HeaderProps>(
+  (
+    { className, children, copyValue, valueDesc, tooltipText, ...props },
+    ref,
+  ) => {
+    const { toast } = useToast();
+    return (
+      <CardHeader ref={ref} className={cn(className)} {...props}>
+        {children}
+        {copyValue && tooltipText && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger
+                className="cursor-point ml-auto"
+                onClick={() => handleCopy(copyValue, valueDesc, toast)}
+              >
+                <Copy className="h-4 w-4 stroke-slate-300" />
+                <span className="sr-only">{"hi"}</span>
+              </TooltipTrigger>
+              <TooltipContent>{tooltipText}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+      </CardHeader>
+    );
+  },
+);
 MetricCardHeader.displayName = "MetricCardHeader";
 
 const MetricCardTitle = React.forwardRef<
@@ -61,10 +95,8 @@ MetricCardDescription.displayName = "MetricCardDescription";
 
 const MetricCardContent = React.forwardRef<
   HTMLDivElement,
-  { tooltipText?: string; copy?: string } & React.HTMLAttributes<HTMLDivElement>
->(({ tooltipText, className, children, copy, ...props }, ref) => {
-  const { toast } = useToast();
-
+  { tooltipText?: string } & React.HTMLAttributes<HTMLDivElement>
+>(({ tooltipText, className, children, ...props }, ref) => {
   return (
     <CardContent
       ref={ref}
@@ -74,32 +106,19 @@ const MetricCardContent = React.forwardRef<
       )}
       {...props}
     >
-      <div className="flex w-full tracking-tight">
-        {!!tooltipText && (
+      <div className="flex w-full max-w-full">
+        {tooltipText ? (
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger className="max-w-full cursor-default">
-                <div className="truncate">{children}</div>
+                <div className="truncate tracking-tight">{children}</div>
               </TooltipTrigger>
               <TooltipContent>{tooltipText}</TooltipContent>
             </Tooltip>
           </TooltipProvider>
+        ) : (
+          <div className="truncate tracking-tight">{children}</div>
         )}
-        {!!copy && !!tooltipText && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger
-                className="cursor-point -mt-4 h-auto w-0"
-                onClick={() => handleCopy(tooltipText, toast)}
-              >
-                <Copy className="h-4 w-4 stroke-slate-300" />
-                <span className="sr-only">{tooltipText}</span>
-              </TooltipTrigger>
-              <TooltipContent>click to copy table name</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        )}
-        {!tooltipText && children}
       </div>
     </CardContent>
   );

--- a/packages/web/components/metric-card.tsx
+++ b/packages/web/components/metric-card.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import * as React from "react";
+import { Copy } from "lucide-react";
 import {
   Card,
   CardContent,
@@ -13,7 +16,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "./ui/tooltip";
-import { cn } from "@/lib/utils";
+import { cn, handleCopy } from "@/lib/utils";
+import { useToast } from "@/components/ui/use-toast";
 
 const MetricCard = React.forwardRef<
   HTMLDivElement,
@@ -57,29 +61,46 @@ MetricCardDescription.displayName = "MetricCardDescription";
 
 const MetricCardContent = React.forwardRef<
   HTMLDivElement,
-  { tooltipText?: string } & React.HTMLAttributes<HTMLDivElement>
->(({ tooltipText, className, children, ...props }, ref) => {
+  { tooltipText?: string; copy?: string } & React.HTMLAttributes<HTMLDivElement>
+>(({ tooltipText, className, children, copy, ...props }, ref) => {
+  const { toast } = useToast();
+
   return (
     <CardContent
       ref={ref}
       className={cn(
-        "m-auto hyphens-auto text-center text-3xl font-semibold tracking-tight",
+        "m-auto text-center text-3xl font-semibold tracking-tight",
         className,
       )}
       {...props}
     >
-      {tooltipText ? (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger className="tracking-tight">
-              {children}
-            </TooltipTrigger>
-            <TooltipContent>{tooltipText}</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      ) : (
-        children
-      )}
+      <div className="flex w-full tracking-tight">
+        {!!tooltipText && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger className="max-w-full cursor-default">
+                <div className="truncate">{children}</div>
+              </TooltipTrigger>
+              <TooltipContent>{tooltipText}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+        {!!copy && !!tooltipText && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger
+                className="cursor-point -mt-4 h-auto w-0"
+                onClick={() => handleCopy(tooltipText, toast)}
+              >
+                <Copy className="h-4 w-4 stroke-slate-300" />
+                <span className="sr-only">{tooltipText}</span>
+              </TooltipTrigger>
+              <TooltipContent>click to copy table name</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+        {!tooltipText && children}
+      </div>
     </CardContent>
   );
 });

--- a/packages/web/components/tableland-table.tsx
+++ b/packages/web/components/tableland-table.tsx
@@ -97,11 +97,16 @@ export default async function TablelandTable({
           <MetricCardFooter>{timeAgo.format(createdAt)}</MetricCardFooter>
         </MetricCard>
         <MetricCard>
-          <MetricCardHeader className="flex flex-row items-center gap-2 space-y-0">
+          <MetricCardHeader
+            className="flex flex-row items-center gap-2 space-y-0"
+            copyValue={tableName}
+            valueDesc="Table name"
+            tooltipText="Click to copy table name"
+          >
             <Table2 className="h-4 w-4 text-muted-foreground" />
             <MetricCardTitle>Tableland Table</MetricCardTitle>
           </MetricCardHeader>
-          <MetricCardContent tooltipText={tableName} copy="true">
+          <MetricCardContent tooltipText={tableName}>
             {tableName}
           </MetricCardContent>
           <MetricCardFooter>
@@ -126,16 +131,19 @@ export default async function TablelandTable({
         </MetricCard>
         {deploymentData?.txnHash && (
           <MetricCard>
-            <MetricCardHeader className="flex flex-row items-center gap-2 space-y-0">
+            <MetricCardHeader
+              className="flex flex-row items-center gap-2 space-y-0"
+              copyValue={deploymentData.txnHash}
+              valueDesc="Txn hash"
+              tooltipText="Click to copy txn hash"
+            >
               <Hash className="h-4 w-4 text-muted-foreground" />
               <MetricCardTitle>Transaction Hash</MetricCardTitle>
             </MetricCardHeader>
             <MetricCardContent>
               <HashDisplay
                 hash={deploymentData.txnHash}
-                copy
                 className="text-3xl text-foreground"
-                hashDesc="txn hash"
               />
             </MetricCardContent>
             {blockExplorer && (

--- a/packages/web/components/tableland-table.tsx
+++ b/packages/web/components/tableland-table.tsx
@@ -101,7 +101,7 @@ export default async function TablelandTable({
             <Table2 className="h-4 w-4 text-muted-foreground" />
             <MetricCardTitle>Tableland Table</MetricCardTitle>
           </MetricCardHeader>
-          <MetricCardContent tooltipText={tableName}>
+          <MetricCardContent tooltipText={tableName} copy="true">
             {tableName}
           </MetricCardContent>
           <MetricCardFooter>

--- a/packages/web/lib/utils.ts
+++ b/packages/web/lib/utils.ts
@@ -1,6 +1,9 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import * as z from "zod";
+import { type useToast } from "@/components/ui/use-toast";
+
+type Toast = ReturnType<typeof useToast>["toast"];
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -32,3 +35,34 @@ export function objectToTableData<TData>(data: any[]) {
     ) as TData;
   });
 }
+
+export const handleCopy = function (text: string, toast: Toast) {
+  // TODO: clickboard write text is probably really fast, so it might not be
+  //    needed here, but some kind lock of the UI when async ops are happening
+  //    could make the ui feel more responsive.
+  navigator.clipboard
+    .writeText(text)
+    .then(function () {
+      toast({
+        title: "Done!",
+        description: `${text} has been copied to your clipboard.`,
+        duration: 2000,
+      });
+    })
+    .catch(function (err) {
+      const errMessage = [
+        `Could not copy ${text} to your clipboard.`,
+        typeof err.message === "string" ? err.message : undefined,
+      ]
+        .filter((s) => s)
+        .join(" ");
+
+      toast({
+        title: "Error!",
+        description: errMessage,
+        // Leave the toast open for 10 seconds so they have a chance to copy
+        // the text in the toast.
+        duration: 10000,
+      });
+    });
+};

--- a/packages/web/lib/utils.ts
+++ b/packages/web/lib/utils.ts
@@ -36,7 +36,7 @@ export function objectToTableData<TData>(data: any[]) {
   });
 }
 
-export const handleCopy = function (text: string, toast: Toast) {
+export const handleCopy = function (text: string, desc: string, toast: Toast) {
   // TODO: clickboard write text is probably really fast, so it might not be
   //    needed here, but some kind lock of the UI when async ops are happening
   //    could make the ui feel more responsive.
@@ -45,13 +45,13 @@ export const handleCopy = function (text: string, toast: Toast) {
     .then(function () {
       toast({
         title: "Done!",
-        description: `${text} has been copied to your clipboard.`,
+        description: `${desc} has been copied to your clipboard.`,
         duration: 2000,
       });
     })
     .catch(function (err) {
       const errMessage = [
-        `Could not copy ${text} to your clipboard.`,
+        `Could not copy ${desc} ${text} to your clipboard.`,
         typeof err.message === "string" ? err.message : undefined,
       ]
         .filter((s) => s)


### PR DESCRIPTION
fixes: https://linear.app/tableland/issue/ENG-823/the-table-pages-table-name-card-has-issues-with-overflow-and-word

The metric card on the table page has issues with the layout and you cannot click to copy the table name.
This PR updates the layout to handle text overflow with an ellipsis truncation, and it enable the same click to copy functionality as the wallet public key in the header.