### PR TITLE
extracting iron-session into api only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       ],
       "devDependencies": {
         "@tableland/local": "^2.4.1",
+        "@types/cookie": "^0.6.0",
         "@types/cosmiconfig": "^6.0.0",
         "@types/inquirer": "^9.0.2",
         "@types/js-yaml": "^4.0.5",
@@ -44,7 +45,6 @@
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-promise": "^6.1.1",
         "husky": "^8.0.3",
-        "iron-session": "^8.0.1",
         "lerna": "^7.1.5",
         "lint-staged": "^13.2.2",
         "mocha": "^10.0.0",
@@ -5164,6 +5164,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true
     },
     "node_modules/@types/cosmiconfig": {
       "version": "6.0.0",
@@ -22570,7 +22576,6 @@
         "clsx": "^2.0.0",
         "cmdk": "^0.2.0",
         "ethers": "^5.7.1",
-        "iron-session": "^8.0.1",
         "javascript-time-ago": "^2.5.9",
         "jotai": "^2.1.1",
         "keccak": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@tableland/local": "^2.4.1",
+    "@types/cookie": "^0.6.0",
     "@types/cosmiconfig": "^6.0.0",
     "@types/inquirer": "^9.0.2",
     "@types/js-yaml": "^4.0.5",
@@ -49,7 +50,6 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-promise": "^6.1.1",
     "husky": "^8.0.3",
-    "iron-session": "^8.0.1",
     "lerna": "^7.1.5",
     "lint-staged": "^13.2.2",
     "mocha": "^10.0.0",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -8,7 +8,12 @@ import {
 } from "./session-data";
 import type { AppRouter } from "./root";
 import { appRouter } from "./root";
-import { createCallerFactory, createTRPCContext } from "./trpc";
+import {
+  type GetSessionArgs,
+  createCallerFactory,
+  createTRPCContext,
+  getSession,
+} from "./trpc";
 
 /**
  * Create a server-side caller for the tRPC API
@@ -41,12 +46,14 @@ export {
   createTRPCContext,
   appRouter,
   createCaller,
+  getSession,
   sessionOptions,
   defaultSession,
 };
 export type {
   AppRouter,
   RouterInputs,
+  GetSessionArgs,
   RouterOutputs,
   Auth,
   SessionData,

--- a/packages/cli/test/setup.ts
+++ b/packages/cli/test/setup.ts
@@ -8,17 +8,11 @@ import { createHash } from "crypto";
 import { NonceManager } from "@ethersproject/experimental";
 import { LocalTableland } from "@tableland/local";
 import { Database, Validator, helpers } from "@tableland/sdk";
-import {
-  type SessionData,
-  appRouter,
-  createTRPCContext as createContext,
-  sessionOptions,
-} from "@tableland/studio-api";
+import { appRouter, createTRPCContext } from "@tableland/studio-api";
 import { init } from "@tableland/studio-store";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import { Wallet, getDefaultProvider } from "ethers";
 import { after, before } from "mocha";
-import { getIronSession } from "iron-session";
 import {
   TEST_API_BASE_URL,
   TEST_API_PORT,
@@ -202,22 +196,16 @@ async function startStudioApi({ store }: { store: Store }) {
         });
       };
 
-      const session = await getIronSession<SessionData>(
-        req,
-        res,
-        sessionOptions,
-      );
-
       const response = await fetchRequestHandler({
         endpoint: "/api/trpc",
         router: apiRouter,
         req,
         createContext: async () => {
-          const context = await createContext({
+          return await createTRPCContext({
             headers: req.headers,
-            session,
+            req,
+            res,
           });
-          return context;
         },
       });
 

--- a/packages/web/app/[team]/(team)/people/page.tsx
+++ b/packages/web/app/[team]/(team)/people/page.tsx
@@ -1,5 +1,7 @@
 import { cache } from "react";
+import { headers, cookies } from "next/headers";
 import { type RouterOutputs } from "@tableland/studio-api";
+import { getSession } from "@tableland/studio-api";
 import Info from "./_components/info";
 import InviteActions from "./_components/invite-actions";
 import NewInvite from "./_components/new-invite";
@@ -8,10 +10,10 @@ import HashDisplay from "@/components/hash-display";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/server";
-import { getSession } from "@/lib/session";
 
 export default async function People({ params }: { params: { team: string } }) {
-  const { auth } = await getSession();
+  const session = await getSession({ cookies: cookies(), headers: headers() });
+  const { auth } = session;
 
   const team = await cache(api.teams.teamBySlug)({ slug: params.team });
   const people = await cache(api.teams.usersForTeam)({

--- a/packages/web/app/api/trpc/[trpc]/route.ts
+++ b/packages/web/app/api/trpc/[trpc]/route.ts
@@ -1,11 +1,6 @@
-import {
-  type SessionData,
-  createTRPCContext as createContext,
-  sessionOptions,
-} from "@tableland/studio-api";
+import { createTRPCContext } from "@tableland/studio-api";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import { cookies } from "next/headers";
-import { getIronSession } from "iron-session";
 import { apiRouter } from "@/lib/api-router";
 
 // TODO: Understand why this should be set to edge and figure out why the crypto module is not available in edge. Might need to upgrade nextjs.
@@ -36,15 +31,10 @@ const handler = async (req: Request) => {
     router: apiRouter,
     req,
     createContext: async () => {
-      const session = await getIronSession<SessionData>(
-        cookies(),
-        sessionOptions,
-      );
-      const context = await createContext({
+      return await createTRPCContext({
         headers: req.headers,
-        session,
+        cookies: cookies(),
       });
-      return context;
     },
     onError({ error, path }) {
       console.error(`>>> tRPC Error on '${path ?? "[undefined path]"}'`, error);

--- a/packages/web/app/invite/page.tsx
+++ b/packages/web/app/invite/page.tsx
@@ -1,5 +1,7 @@
+import { headers, cookies } from "next/headers";
 import { notFound } from "next/navigation";
 import { cache } from "react";
+import { getSession } from "@tableland/studio-api";
 import { api } from "@/trpc/server";
 import {
   Card,
@@ -10,7 +12,6 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import InviteHandler from "@/components/invite-handler";
-import { getSession } from "@/lib/session";
 
 export default async function Invite({
   searchParams,
@@ -36,7 +37,7 @@ export default async function Invite({
     teamId: invite.inviterTeamId,
   });
 
-  const session = await getSession();
+  const session = await getSession({ cookies: cookies(), headers: headers() });
 
   return (
     <div className="flex flex-1 flex-col items-center justify-center p-4">

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -1,9 +1,9 @@
-import { type RouterOutputs } from "@tableland/studio-api";
+import { type RouterOutputs, getSession } from "@tableland/studio-api";
 import TimeAgo from "javascript-time-ago";
 import en from "javascript-time-ago/locale/en";
 import dynamic from "next/dynamic";
 import { Source_Code_Pro, Source_Sans_3 } from "next/font/google";
-import { headers } from "next/headers";
+import { headers, cookies } from "next/headers";
 import Link from "next/link";
 import Script from "next/script";
 import { cache } from "react";
@@ -20,7 +20,6 @@ import Hotjar from "@/components/hotjar";
 import { JotaiProvider } from "@/components/jotai-provider";
 import "./globals.css";
 import { TimeAgoProvider } from "@/components/time-ago-provider";
-import { getSession } from "@/lib/session";
 
 TimeAgo.addDefaultLocale(en);
 
@@ -54,7 +53,7 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const session = await getSession();
+  const session = await getSession({ cookies: cookies(), headers: headers() });
   let teams: RouterOutputs["teams"]["userTeams"] = [];
   if (session.auth) {
     try {

--- a/packages/web/app/new-team/page.tsx
+++ b/packages/web/app/new-team/page.tsx
@@ -1,9 +1,10 @@
+import { getSession } from "@tableland/studio-api";
+import { headers, cookies } from "next/headers";
 import { notFound } from "next/navigation";
 import NewTeamForm from "./_components/new-team-form";
-import { getSession } from "@/lib/session";
 
 export default async function NewProject() {
-  const session = await getSession();
+  const session = await getSession({ headers: headers(), cookies: cookies() });
   if (!session.auth) {
     notFound();
   }

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -7,7 +7,8 @@ import {
   Play,
 } from "lucide-react";
 import Link from "next/link";
-import { type RouterOutputs } from "@tableland/studio-api";
+import { headers, cookies } from "next/headers";
+import { type RouterOutputs, getSession } from "@tableland/studio-api";
 import { cache } from "react";
 import { LatestTables } from "./_components/latest-tables";
 import { PopularTables } from "./_components/popular-tables";
@@ -21,10 +22,9 @@ import { store } from "@/lib/store";
 import TeamAvatar from "@/components/team-avatar";
 import { getLatestTables, getPopularTables } from "@/lib/validator-queries";
 import { api } from "@/trpc/server";
-import { getSession } from "@/lib/session";
 
 export default async function Page() {
-  const session = await getSession();
+  const session = await getSession({ headers: headers(), cookies: cookies() });
 
   let teams: RouterOutputs["teams"]["userTeams"] = [];
   if (session.auth) {

--- a/packages/web/lib/session.ts
+++ b/packages/web/lib/session.ts
@@ -1,8 +1,0 @@
-import { cookies } from "next/headers";
-import { getIronSession } from "iron-session";
-import { type SessionData, sessionOptions } from "@tableland/studio-api";
-
-export async function getSession() {
-  const session = await getIronSession<SessionData>(cookies(), sessionOptions);
-  return session;
-}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -52,7 +52,6 @@
     "clsx": "^2.0.0",
     "cmdk": "^0.2.0",
     "ethers": "^5.7.1",
-    "iron-session": "^8.0.1",
     "javascript-time-ago": "^2.5.9",
     "jotai": "^2.1.1",
     "keccak": "^3.0.3",

--- a/packages/web/trpc/server.ts
+++ b/packages/web/trpc/server.ts
@@ -1,12 +1,6 @@
 import { cookies, headers } from "next/headers";
 import { cache } from "react";
-import {
-  type SessionData,
-  createCaller,
-  createTRPCContext,
-  sessionOptions,
-} from "@tableland/studio-api";
-import { getIronSession } from "iron-session";
+import { createCaller, createTRPCContext } from "@tableland/studio-api";
 import { apiRouter } from "@/lib/api-router";
 
 /**
@@ -17,11 +11,9 @@ const createContext = cache(async () => {
   const heads = new Headers(headers());
   heads.set("x-trpc-source", "rsc");
 
-  const session = await getIronSession<SessionData>(cookies(), sessionOptions);
-
   return await createTRPCContext({
     headers: heads,
-    session,
+    cookies: cookies(),
   });
 });
 


### PR DESCRIPTION
While reviewing #231 I noticed that the consumers of the api package have to have iron-session as a dependency.  It seems like that should be a dep of api and the api package can contain the session logic.

Let's discuss in office hours