### PR TITLE
Joe/publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22643,7 +22643,7 @@
     },
     "packages/cli": {
       "name": "@tableland/studio-cli",
-      "version": "0.0.0-pre.11",
+      "version": "0.0.1",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@tableland/sdk": "^6.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/studio-cli",
-  "version": "0.0.0-pre.11",
+  "version": "0.0.1",
   "description": "Tableland command line tools",
   "repository": "https://github.com/tablelandnetwork/studio/cli",
   "publishConfig": {


### PR DESCRIPTION
Set CLI to first official version.
note, no changes since the last pre-release.  
fixes: https://linear.app/tableland/issue/SHI-221/publish-official-cli-release-for-studio-v1