### PR TITLE
Display list of projects using table

### DIFF
--- a/packages/api/src/routers/deployments.ts
+++ b/packages/api/src/routers/deployments.ts
@@ -55,5 +55,18 @@ export function deploymentsRouter(store: Store) {
           input.environmentId,
         );
       }),
+    deploymentReferences: publicProcedure
+      .input(
+        z.object({
+          chainId: z.number().int().gt(0),
+          tokenId: z.string().trim().nonempty(),
+        }),
+      )
+      .query(async ({ input }) => {
+        return await store.deployments.deploymentReferences(
+          input.chainId,
+          input.tokenId,
+        );
+      }),
   });
 }

--- a/packages/web/app/[team]/[project]/(project)/deployments/[[...slug]]/_components/sidebar.tsx
+++ b/packages/web/app/[team]/[project]/(project)/deployments/[[...slug]]/_components/sidebar.tsx
@@ -73,7 +73,7 @@ export function Sidebar({
             return isAuthorized || deployment ? (
               <Link
                 key={table.id}
-                href={`/${teamSlug}/${projectSlug}/deployments/${environment.slug}/${table.name}`}
+                href={`/${teamSlug}/${projectSlug}/deployments/${environment.slug}/${table.slug}`}
               >
                 {button}
               </Link>

--- a/packages/web/app/[team]/[project]/(project)/deployments/[[...slug]]/page.tsx
+++ b/packages/web/app/[team]/[project]/(project)/deployments/[[...slug]]/page.tsx
@@ -51,7 +51,7 @@ export default async function Deployments({
     selectedEnvironment = environments.find(
       (environment) => environment.slug === envSlug,
     );
-    selectedTable = tables.find((table) => table.name === tableSlug);
+    selectedTable = tables.find((table) => table.slug === tableSlug);
     if (!selectedEnvironment || !selectedTable) {
       notFound();
     }

--- a/packages/web/components/projects-referencing-table.tsx
+++ b/packages/web/components/projects-referencing-table.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { type RouterOutputs } from "@tableland/studio-api";
+import Link from "next/link";
+import { type ComponentProps } from "react";
+import { ScrollArea } from "./ui/scroll-area";
+
+type Props = {
+  references: RouterOutputs["deployments"]["deploymentReferences"];
+} & ComponentProps<typeof ScrollArea>;
+
+export default function ProjectsReferencingTable({
+  references,
+  ...rest
+}: Props) {
+  return (
+    <ScrollArea {...rest}>
+      <ul className="space-y-1">
+        {references.map((p) => (
+          <li key={p.project.id}>
+            <Link
+              href={`/${p.team.slug}/${p.project.slug}/deployments/${p.environment.slug}/${p.table.slug}`}
+              className="text-foreground"
+            >
+              {p.team.name}/{p.project.name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </ScrollArea>
+  );
+}

--- a/packages/web/components/tableland-table.tsx
+++ b/packages/web/components/tableland-table.tsx
@@ -1,7 +1,7 @@
 import { Database, Validator, type Schema, helpers } from "@tableland/sdk";
 import { type schema } from "@tableland/studio-store";
 import { type ColumnDef } from "@tanstack/react-table";
-import { Blocks, Coins, Hash, Rocket, Table2 } from "lucide-react";
+import { Blocks, Coins, Hash, Rocket, Table2, Workflow } from "lucide-react";
 import Link from "next/link";
 import { DataTable } from "../app/[team]/[project]/(project)/deployments/[[...slug]]/_components/data-table";
 import {
@@ -15,11 +15,14 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 import SQLLogs from "./sql-logs";
 import HashDisplay from "./hash-display";
 import TablelandTableMenu from "./tableland-table-menu";
+import { CardContent } from "./ui/card";
+import ProjectsReferencingTable from "./projects-referencing-table";
 import { blockExplorers } from "@/lib/block-explorers";
 import { openSeaLinks } from "@/lib/open-sea";
 import { chainsMap } from "@/lib/chains-map";
 import { objectToTableData } from "@/lib/utils";
 import { TimeSince } from "@/components/time";
+import { api } from "@/trpc/server";
 
 interface Props {
   displayName: string;
@@ -74,6 +77,9 @@ export default async function TablelandTable({
       }))
     : [];
   const table = await validator.getTableById({ chainId, tableId: tokenId });
+  const deploymentReferences = (
+    await api.deployments.deploymentReferences({ chainId, tokenId })
+  ).filter((p) => p.environment.id !== environment?.id);
 
   return (
     <div className="flex-1 space-y-4 p-4">
@@ -187,6 +193,22 @@ export default async function TablelandTable({
                 </Link>
               </MetricCardFooter>
             )}
+          </MetricCard>
+        )}
+        {deploymentReferences.length > 0 && (
+          <MetricCard>
+            <MetricCardHeader className="flex flex-row items-center gap-2 space-y-0">
+              <Workflow className="h-4 w-4 text-muted-foreground" />
+              <MetricCardTitle>
+                Studio projects using this table
+              </MetricCardTitle>
+            </MetricCardHeader>
+            <CardContent>
+              <ProjectsReferencingTable
+                references={deploymentReferences}
+                className="h-[80px]"
+              />
+            </CardContent>
           </MetricCard>
         )}
       </div>


### PR DESCRIPTION
On the tableland table page, created a new card that lists all Studio projects that reference the table. This required a new `store` function which is also exposed throught the `api` package.

Closes ENG-743