### PR TITLE
(nonce) set expire on delta redis key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22497,7 +22497,7 @@
     },
     "packages/nonce": {
       "name": "@tableland/nonce",
-      "version": "0.0.0-pre.1",
+      "version": "0.0.1",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@upstash/redis": "^1.28.3",
@@ -23005,6 +23005,15 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "packages/web/node_modules/@tableland/nonce": {
+      "version": "0.0.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@tableland/nonce/-/nonce-0.0.0-pre.1.tgz",
+      "integrity": "sha512-qunkdCxCdBqTklwhbeamXHQWSaBhT9ch1vlkOuPhRdEm5czgoYjPKyRnDWdmVRXNYRKICILcQhIV5eY1IkeZEA==",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3",
+        "ethers": "^5.7.0"
       }
     },
     "packages/web/node_modules/@tableland/sdk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22559,7 +22559,7 @@
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.5",
         "@radix-ui/react-tooltip": "^1.0.7",
-        "@tableland/nonce": "^0.0.0-pre.1",
+        "@tableland/nonce": "^0.0.1",
         "@tableland/sdk": "^6.0.0",
         "@tableland/studio-api": "^0.0.0-pre.2",
         "@tableland/studio-chains": "^0.0.0-pre.1",
@@ -23005,15 +23005,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "packages/web/node_modules/@tableland/nonce": {
-      "version": "0.0.0-pre.1",
-      "resolved": "https://registry.npmjs.org/@tableland/nonce/-/nonce-0.0.0-pre.1.tgz",
-      "integrity": "sha512-qunkdCxCdBqTklwhbeamXHQWSaBhT9ch1vlkOuPhRdEm5czgoYjPKyRnDWdmVRXNYRKICILcQhIV5eY1IkeZEA==",
-      "dependencies": {
-        "@upstash/redis": "^1.28.3",
-        "ethers": "^5.7.0"
       }
     },
     "packages/web/node_modules/@tableland/sdk": {

--- a/packages/nonce/package.json
+++ b/packages/nonce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/nonce",
-  "version": "0.0.0-pre.1",
+  "version": "0.0.1",
   "description": "",
   "repository": "https://github.com/tablelandnetwork/studio/nonce",
   "publishConfig": {

--- a/packages/nonce/src/main.ts
+++ b/packages/nonce/src/main.ts
@@ -202,14 +202,11 @@ export class NonceManager extends ethers.Signer {
     this._lock = undefined;
   }
 
-  // NOTE: The delta key expires in 30 seconds. This should be about right for
-  //       Nova's average of 12 seconds per block.
+  // NOTE: The delta key expires in 30 seconds. This should be fine for Nova.
   async _resetDelta() {
     await this.memStore.eval(
       `if redis.call("get",KEYS[1]) ~= ARGV[1] then
-          local ret = redis.call("set",KEYS[1], 0)
-          redis.call("expire", KEYS[1], 30)
-          return ret
+          return redis.call("setex", KEYS[1], 30, 0)
       else
           return 0
       end`,

--- a/packages/nonce/src/main.ts
+++ b/packages/nonce/src/main.ts
@@ -202,10 +202,14 @@ export class NonceManager extends ethers.Signer {
     this._lock = undefined;
   }
 
+  // NOTE: The delta key expires in 30 seconds. This should be about right for
+  //       Nova's average of 12 seconds per block.
   async _resetDelta() {
     await this.memStore.eval(
       `if redis.call("get",KEYS[1]) ~= ARGV[1] then
-          return redis.call("set",KEYS[1], 0)
+          local ret = redis.call("set",KEYS[1], 0)
+          redis.call("expire", KEYS[1], 30)
+          return ret
       else
           return 0
       end`,

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,7 +36,7 @@
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-tooltip": "^1.0.7",
-    "@tableland/nonce": "^0.0.0-pre.1",
+    "@tableland/nonce": "^0.0.1",
     "@tableland/sdk": "^6.0.0",
     "@tableland/studio-api": "^0.0.0-pre.2",
     "@tableland/studio-chains": "^0.0.0-pre.1",

--- a/packages/web/vercel.json
+++ b/packages/web/vercel.json
@@ -1,4 +1,9 @@
 {
   "trailingSlash": false,
-  "github": { "silent": true }
+  "github": { "silent": true },
+  "functions": {
+    "app/**/*": {
+      "maxDuration": 60
+    }
+  }
 }


### PR DESCRIPTION
Included here:

- updates the nonce manager to ensure that the `delta:*` keys have an automatic expiration.
- increase vercel max function duration to 60 seconds.

The combination of these two things should illiminate the issue of nonce deltas getting stuck when vercel timeout errors occur. 