### PR TITLE
(web,nonce) enabling local dev without redis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22503,7 +22503,7 @@
     },
     "packages/nonce": {
       "name": "@tableland/nonce",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@upstash/redis": "^1.28.3",
@@ -22596,7 +22596,7 @@
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.5",
         "@radix-ui/react-tooltip": "^1.0.7",
-        "@tableland/nonce": "^0.0.1",
+        "@tableland/nonce": "^0.0.2",
         "@tableland/sdk": "^6.0.0",
         "@tableland/studio-api": "^0.0.0-pre.2",
         "@tableland/studio-chains": "^0.0.0-pre.1",

--- a/packages/nonce/package.json
+++ b/packages/nonce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/nonce",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "repository": "https://github.com/tablelandnetwork/studio/packages/nonce",
   "publishConfig": {

--- a/packages/nonce/src/main.ts
+++ b/packages/nonce/src/main.ts
@@ -21,22 +21,24 @@ export class NonceManager extends ethers.Signer {
 
   _lock: string | undefined;
 
-  constructor(signer: ethers.Signer) {
+  constructor(
+    signer: ethers.Signer,
+    opts: { redisUrl: string; redisToken: string },
+  ) {
     super();
     if (typeof signer.provider === "undefined") {
       throw new Error("NonceManager requires a provider at instantiation");
     }
-
-    if (
-      typeof process.env.KV_REST_API_URL !== "string" ||
-      typeof process.env.KV_REST_API_TOKEN !== "string"
-    ) {
-      throw new Error("Vercel KV api env variables are not available");
+    if (typeof opts.redisUrl !== "string") {
+      throw new Error("NonceManager requires a redis url at instantiation");
+    }
+    if (typeof opts.redisToken !== "string") {
+      throw new Error("NonceManager requires a redis token at instantiation");
     }
 
     this.memStore = new Redis({
-      url: process.env.KV_REST_API_URL,
-      token: process.env.KV_REST_API_TOKEN,
+      url: opts.redisUrl,
+      token: opts.redisToken,
     });
     this.signer = signer;
     this.provider = signer.provider;

--- a/packages/nonce/src/main.ts
+++ b/packages/nonce/src/main.ts
@@ -8,18 +8,6 @@ dotenv.config();
 // TODO: Keep a per-NonceManager pool of sent but unmined transactions for
 //    rebroadcasting, in case we overrun the transaction pool
 
-if (
-  typeof process.env.KV_REST_API_URL !== "string" ||
-  typeof process.env.KV_REST_API_TOKEN !== "string"
-) {
-  throw new Error("Vercel KV api env variables are not available");
-}
-
-const redis = new Redis({
-  url: process.env.KV_REST_API_URL,
-  token: process.env.KV_REST_API_TOKEN,
-});
-
 // The logic we need to implement here should follow the ethers.js
 // implementation logic, but the delta from on chain nonce
 
@@ -29,7 +17,7 @@ export class NonceManager extends ethers.Signer {
 
   // This redis instance is a singleton in the scope of all NonceManager
   // instances in this process, i.e. each process gets a single redis client.
-  readonly memStore = redis;
+  readonly memStore: Redis;
 
   _lock: string | undefined;
 
@@ -39,6 +27,17 @@ export class NonceManager extends ethers.Signer {
       throw new Error("NonceManager requires a provider at instantiation");
     }
 
+    if (
+      typeof process.env.KV_REST_API_URL !== "string" ||
+      typeof process.env.KV_REST_API_TOKEN !== "string"
+    ) {
+      throw new Error("Vercel KV api env variables are not available");
+    }
+
+    this.memStore = new Redis({
+      url: process.env.KV_REST_API_URL,
+      token: process.env.KV_REST_API_TOKEN,
+    });
     this.signer = signer;
     this.provider = signer.provider;
   }

--- a/packages/nonce/test/main.test.ts
+++ b/packages/nonce/test/main.test.ts
@@ -71,11 +71,24 @@ describe("NonceManager", function () {
     const wallet1 = new Wallet(account2);
     const wallet2 = new Wallet(account2);
 
+    if (
+      typeof process.env.KV_REST_API_URL !== "string" ||
+      typeof process.env.KV_REST_API_TOKEN !== "string"
+    ) {
+      throw new Error("Vercel KV api env variables are not available");
+    }
+
     const db1 = new Database({
-      signer: new NonceManager(wallet1.connect(provider1)),
+      signer: new NonceManager(wallet1.connect(provider1), {
+        redisUrl: process.env.KV_REST_API_URL,
+        redisToken: process.env.KV_REST_API_TOKEN,
+      }),
     });
     const db2 = new Database({
-      signer: new NonceManager(wallet2.connect(provider2)),
+      signer: new NonceManager(wallet2.connect(provider2), {
+        redisUrl: process.env.KV_REST_API_URL,
+        redisToken: process.env.KV_REST_API_TOKEN,
+      }),
     });
 
     const results = await Promise.all([

--- a/packages/nonce/test/process-with.js
+++ b/packages/nonce/test/process-with.js
@@ -13,7 +13,10 @@ const account = "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab3
 const provider = getDefaultProvider(`http://127.0.0.1:${process.env.TEST_REGISTRY_PORT}`);
 const wallet = new Wallet(account);
 const db = new Database({
-  signer: new NonceManager(wallet.connect(provider)),
+  signer: new NonceManager(wallet.connect(provider), {
+    redisUrl: process.env.KV_REST_API_URL,
+    redisToken: process.env.KV_REST_API_TOKEN,
+  }),
   registryPort: process.env.TEST_REGISTRY_PORT,
   autoWait: true,
 });

--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -5,5 +5,10 @@ SESSION_COOKIE_NAME=STUDIO_SESSION
 SESSION_COOKIE_PASS="secure password secure password secure password secure password secure password secure password secure password"
 DATA_SEAL_PASS="secure password secure password secure password secure password secure password secure password secure password"
 DATA_SEAL_PASS="secure password secure password secure password"
+
+# use redis backed nonce manager
 KV_REST_API_URL="https://your-example-domain.upstash.io"
 KV_REST_API_TOKEN="your_kv_api_token"
+
+# use an in-memory nonce manager
+KV_LOCAL_DEV=true

--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -6,9 +6,6 @@ SESSION_COOKIE_PASS="secure password secure password secure password secure pass
 DATA_SEAL_PASS="secure password secure password secure password secure password secure password secure password secure password"
 DATA_SEAL_PASS="secure password secure password secure password"
 
-# use redis backed nonce manager
+# use redis backed nonce manager, if these are not provided the app will use an in-memory nonce manager
 KV_REST_API_URL="https://your-example-domain.upstash.io"
 KV_REST_API_TOKEN="your_kv_api_token"
-
-# use an in-memory nonce manager
-KV_LOCAL_DEV=true

--- a/packages/web/lib/wallet.ts
+++ b/packages/web/lib/wallet.ts
@@ -11,6 +11,10 @@ export const provider = getDefaultProvider(process.env.PROVIDER_URL);
 const baseSigner = wallet.connect(provider);
 
 export const signer =
-  typeof process.env.KV_LOCAL_DEV === "string"
+  typeof process.env.KV_REST_API_URL !== "string" ||
+  typeof process.env.KV_REST_API_TOKEN !== "string"
     ? new EthersNonceManager(baseSigner)
-    : new TablelandNonceManager(baseSigner);
+    : new TablelandNonceManager(baseSigner, {
+        redisUrl: process.env.KV_REST_API_URL,
+        redisToken: process.env.KV_REST_API_TOKEN,
+      });

--- a/packages/web/lib/wallet.ts
+++ b/packages/web/lib/wallet.ts
@@ -1,5 +1,6 @@
 import { Wallet, getDefaultProvider } from "ethers";
-import { NonceManager } from "@tableland/nonce";
+import { NonceManager as TablelandNonceManager } from "@tableland/nonce";
+import { NonceManager as EthersNonceManager } from "@ethersproject/experimental";
 
 if (!process.env.STORE_PRIVATE_KEY) {
   throw new Error("Must provide STORE_PRIVATE_KEY env var.");
@@ -8,4 +9,8 @@ if (!process.env.STORE_PRIVATE_KEY) {
 const wallet = new Wallet(process.env.STORE_PRIVATE_KEY);
 export const provider = getDefaultProvider(process.env.PROVIDER_URL);
 const baseSigner = wallet.connect(provider);
-export const signer = new NonceManager(baseSigner);
+
+export const signer =
+  typeof process.env.KV_LOCAL_DEV === "string"
+    ? new EthersNonceManager(baseSigner)
+    : new TablelandNonceManager(baseSigner);

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,7 +36,7 @@
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-tooltip": "^1.0.7",
-    "@tableland/nonce": "^0.0.1",
+    "@tableland/nonce": "^0.0.2",
     "@tableland/sdk": "^6.0.0",
     "@tableland/studio-api": "^0.0.0-pre.2",
     "@tableland/studio-chains": "^0.0.0-pre.1",


### PR DESCRIPTION
## Overview

Enable using the in-memory nonce manager for local dev.

## Details

If the `KV_LOCAL_DEV` environment variable is set then the in-memory nonce manager is used, otherwise you must provide redis connection env vars as usual.