### PR TITLE
API helpers to catch not found error

### DIFF
--- a/packages/web/app/[team]/(team)/page.tsx
+++ b/packages/web/app/[team]/(team)/page.tsx
@@ -11,6 +11,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { api } from "@/trpc/server";
+import { teamBySlug } from "@/lib/api-helpers";
 
 export default async function Projects({
   params,
@@ -18,7 +19,7 @@ export default async function Projects({
   params: { team: string };
 }) {
   // TODO: Make some high level API call to return a summary of all projects.
-  const team = await cache(api.teams.teamBySlug)({ slug: params.team });
+  const team = await teamBySlug(params.team);
   const projects = await cache(api.projects.teamProjects)({
     teamId: team.id,
   });

--- a/packages/web/app/[team]/(team)/people/page.tsx
+++ b/packages/web/app/[team]/(team)/people/page.tsx
@@ -10,12 +10,13 @@ import HashDisplay from "@/components/hash-display";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/server";
+import { teamBySlug } from "@/lib/api-helpers";
 
 export default async function People({ params }: { params: { team: string } }) {
   const session = await getSession({ cookies: cookies(), headers: headers() });
   const { auth } = session;
 
-  const team = await cache(api.teams.teamBySlug)({ slug: params.team });
+  const team = await teamBySlug(params.team);
   const people = await cache(api.teams.usersForTeam)({
     teamId: team.id,
   });

--- a/packages/web/app/[team]/[project]/(project)/page.tsx
+++ b/packages/web/app/[team]/[project]/(project)/page.tsx
@@ -14,17 +14,15 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { projectBySlug, teamBySlug } from "@/lib/api-helpers";
 
 export default async function Project({
   params,
 }: {
   params: { team: string; project: string };
 }) {
-  const team = await cache(api.teams.teamBySlug)({ slug: params.team });
-  const project = await cache(api.projects.projectBySlug)({
-    teamId: team.id,
-    slug: params.project,
-  });
+  const team = await teamBySlug(params.team);
+  const project = await projectBySlug(params.project, team.id);
   const envs = await cache(api.environments.projectEnvironments)({
     projectId: project.id,
   });

--- a/packages/web/app/[team]/[project]/(project)/tables/[[...slug]]/page.tsx
+++ b/packages/web/app/[team]/[project]/(project)/tables/[[...slug]]/page.tsx
@@ -7,6 +7,7 @@ import ExecDeployment from "./_components/exec-deployment";
 import { Sidebar } from "./_components/sidebar";
 import Table from "@/components/table";
 import { api } from "@/trpc/server";
+import { projectBySlug, teamBySlug } from "@/lib/api-helpers";
 
 export default async function Deployments({
   params,
@@ -17,14 +18,11 @@ export default async function Deployments({
     notFound();
   }
 
-  const team = await cache(api.teams.teamBySlug)({ slug: params.team });
+  const team = await teamBySlug(params.team);
   const authorized = await cache(api.teams.isAuthorized)({
     teamId: team.id,
   });
-  const project = await cache(api.projects.projectBySlug)({
-    teamId: team.id,
-    slug: params.project,
-  });
+  const project = await projectBySlug(params.project, team.id);
   const environments = await cache(api.environments.projectEnvironments)({
     projectId: project.id,
   });

--- a/packages/web/app/[team]/[project]/[def]/page.tsx
+++ b/packages/web/app/[team]/[project]/[def]/page.tsx
@@ -13,17 +13,15 @@ import {
 } from "@/components/ui/card";
 import DefColumns from "@/components/def-columns";
 import DefConstraints from "@/components/def-constraints";
+import { projectBySlug, teamBySlug } from "@/lib/api-helpers";
 
 export default async function DefDetails({
   params,
 }: {
   params: { team: string; project: string; def: string };
 }) {
-  const team = await cache(api.teams.teamBySlug)({ slug: params.team });
-  const project = await cache(api.projects.projectBySlug)({
-    teamId: team.id,
-    slug: params.project,
-  });
+  const team = await teamBySlug(params.team);
+  const project = await projectBySlug(params.project, team.id);
   const def = await cache(api.defs.defByProjectIdAndSlug)({
     projectId: project.id,
     slug: params.def,

--- a/packages/web/lib/api-helpers.ts
+++ b/packages/web/lib/api-helpers.ts
@@ -1,0 +1,23 @@
+import { TRPCError } from "@trpc/server";
+import { notFound } from "next/navigation";
+import { cache } from "react";
+import { api } from "@/trpc/server";
+
+export async function teamBySlug(slug: string) {
+  return await catch404(async () => await cache(api.teams.teamBySlug)({ slug }));
+}
+
+export async function projectBySlug(slug: string, teamId?: string) {
+  return await catch404(async () => await cache(api.projects.projectBySlug)({ teamId, slug }));
+}
+
+async function catch404<T>(work: () => Promise<T>) {
+  try {
+    return await work();
+  } catch (e) {
+    if (e instanceof TRPCError && e.code === "NOT_FOUND") {
+      notFound();
+    }
+    throw e;
+  }
+}

--- a/packages/web/lib/api-helpers.ts
+++ b/packages/web/lib/api-helpers.ts
@@ -4,11 +4,15 @@ import { cache } from "react";
 import { api } from "@/trpc/server";
 
 export async function teamBySlug(slug: string) {
-  return await catch404(async () => await cache(api.teams.teamBySlug)({ slug }));
+  return await catch404(
+    async () => await cache(api.teams.teamBySlug)({ slug }),
+  );
 }
 
 export async function projectBySlug(slug: string, teamId?: string) {
-  return await catch404(async () => await cache(api.projects.projectBySlug)({ teamId, slug }));
+  return await catch404(
+    async () => await cache(api.projects.projectBySlug)({ teamId, slug }),
+  );
 }
 
 async function catch404<T>(work: () => Promise<T>) {


### PR DESCRIPTION
When we query for team or project based on a slug in the url, often the slug is wrong because of a user typo or web crawler or hacker. This was resulting in error stack traces printed in our logs for the NOT_FOUND error and a generic error component being displayed to the user. 

This PR provides some helpers to those API calls that catches the error, checks if it's a 404, and displays our 404 not found page if so.