### PR TITLE
(web) fix siwe Brave browser incompat in local

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4478,12 +4478,12 @@
       }
     },
     "node_modules/@spruceid/siwe-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.2.tgz",
-      "integrity": "sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.1.2.tgz",
+      "integrity": "sha512-d/r3S1LwJyMaRAKQ0awmo9whfXeE88Qt00vRj91q5uv5ATtWIQEGJ67Yr5eSZw5zp1/fZCXZYuEckt8lSkereQ==",
       "dependencies": {
         "@noble/hashes": "^1.1.2",
-        "apg-js": "^4.1.1",
+        "apg-js": "^4.3.0",
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"
       }
@@ -6469,9 +6469,9 @@
       }
     },
     "node_modules/apg-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.2.0.tgz",
-      "integrity": "sha512-4WI3AYN9DmJWK3+3r/DtVMI+RO45R0u/b7tJWb5EM2c8nIzojx8Oq5LpMalou3sQnmS9qzw7cKmHBrAjdlseWw=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.4.0.tgz",
+      "integrity": "sha512-fefmXFknJmtgtNEXfPwZKYkMFX4Fyeyz+fNF6JWp87biGOPslJbCBVU158zvKRZfHBKnJDy8CMM40oLFGkXT8Q=="
     },
     "node_modules/aproba": {
       "version": "2.0.0",
@@ -19128,11 +19128,11 @@
       "dev": true
     },
     "node_modules/siwe": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.1.4.tgz",
-      "integrity": "sha512-Dke1Qqa3mgiLm3vjqw/+SQ7dl8WV/Pfk3AlQBF94cBFydTYhztngqYrikzE3X5UTsJ6565dfVbQptszsuYZNYg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.3.2.tgz",
+      "integrity": "sha512-aSf+6+Latyttbj5nMu6GF3doMfv2UYj83hhwZgUF20ky6fTS83uVhkQABdIVnEuS8y1bBdk7p6ltb9SmlhTTlA==",
       "dependencies": {
-        "@spruceid/siwe-parser": "*",
+        "@spruceid/siwe-parser": "^2.1.2",
         "@stablelib/random": "^1.0.1",
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"
@@ -21612,7 +21612,7 @@
         "@tableland/studio-validators": "^0.0.0-pre.1",
         "@trpc/server": "^11.0.0-next-beta.318",
         "iron-session": "^8.0.1",
-        "siwe": "^2.1.4",
+        "siwe": "^2.3.2",
         "superjson": "^2.2.1"
       }
     },
@@ -22623,7 +22623,7 @@
         "react-dom": "18.2.0",
         "react-hook-form": "^7.46.2",
         "react-share": "^4.4.1",
-        "siwe": "^2.1.4",
+        "siwe": "^2.3.2",
         "superjson": "^2.2.1",
         "tailwind-merge": "^1.14.0",
         "tailwindcss-animate": "^1.0.7",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -28,7 +28,7 @@
     "@tableland/studio-validators": "^0.0.0-pre.1",
     "@trpc/server": "^11.0.0-next-beta.318",
     "iron-session": "^8.0.1",
-    "siwe": "^2.1.4",
+    "siwe": "^2.3.2",
     "superjson": "^2.2.1"
   }
 }

--- a/packages/web/components/sign-in-button.tsx
+++ b/packages/web/components/sign-in-button.tsx
@@ -46,8 +46,13 @@ export default function SignInButton({
         const chainId = chain?.id;
         if (!address || !chainId) return;
 
+        const proto = window.location.protocol;
+        const colonIndex = proto.indexOf(":");
+        const scheme = ~colonIndex ? proto.slice(0, colonIndex) : "";
+
         // Create SIWE message with pre-fetched nonce and sign with wallet
         const rawMessage = new SiweMessage({
+          scheme,
           domain: window.location.host,
           address,
           statement:

--- a/packages/web/components/sign-in-button.tsx
+++ b/packages/web/components/sign-in-button.tsx
@@ -46,13 +46,9 @@ export default function SignInButton({
         const chainId = chain?.id;
         if (!address || !chainId) return;
 
-        const proto = window.location.protocol;
-        const colonIndex = proto.indexOf(":");
-        const scheme = ~colonIndex ? proto.slice(0, colonIndex) : "";
-
         // Create SIWE message with pre-fetched nonce and sign with wallet
         const rawMessage = new SiweMessage({
-          scheme,
+          scheme: window.location.protocol.slice(0, -1),
           domain: window.location.host,
           address,
           statement:

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -63,7 +63,7 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.46.2",
     "react-share": "^4.4.1",
-    "siwe": "^2.1.4",
+    "siwe": "^2.3.2",
     "superjson": "^2.2.1",
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
The Brave browser includes the siwe message scheme regardless of if it is provided.  The default is `https`, so when we are working locally we need to explicitly provide the `http` scheme.

fixes: https://linear.app/tableland/issue/ENG-849/local-dev-team-invites-dont-seem-to-work-in-brave