### PR TITLE
Use redirect to default env

### DIFF
--- a/packages/web/app/[team]/(team)/_components/new-project-button.tsx
+++ b/packages/web/app/[team]/(team)/_components/new-project-button.tsx
@@ -20,8 +20,7 @@ export default function NewProjectButton({ team }: { team: schema.Team }) {
       }
       onSuccess={(project) => {
         router.refresh();
-        // TODO: Deal with multiple envs
-        router.push(`/${team.slug}/${project.slug}/default`);
+        router.push(`/${team.slug}/${project.slug}`);
       }}
     ></NewProjectForm>
   );

--- a/packages/web/app/[team]/(team)/page.tsx
+++ b/packages/web/app/[team]/(team)/page.tsx
@@ -77,10 +77,7 @@ export default async function Projects({
             const defCount = defs[i].length;
             const deploymentsCount = deployments[i].length;
             return (
-              <Link
-                key={project.id}
-                href={`/${team.slug}/${project.slug}/default`} // TODO: Handle multiple environments and read from local storage or session.
-              >
+              <Link key={project.id} href={`/${team.slug}/${project.slug}`}>
                 <Card className="">
                   <CardHeader>
                     <CardTitle>{project.name}</CardTitle>

--- a/packages/web/app/[team]/[project]/page.tsx
+++ b/packages/web/app/[team]/[project]/page.tsx
@@ -1,0 +1,20 @@
+import { RedirectType, redirect } from "next/navigation";
+
+export default function Page({
+  params,
+  searchParams,
+}: {
+  params: { team: string; project: string };
+  searchParams: Record<string, string | string[] | undefined>;
+}) {
+  let table = "";
+  if (typeof searchParams.table === "string") {
+    table = `/${searchParams.table}`;
+  }
+
+  // TODO: Look up correct env in user session.
+  redirect(
+    `/${params.team}/${params.project}/default${table}`,
+    RedirectType.replace,
+  );
+}

--- a/packages/web/app/_components/latest-projects.tsx
+++ b/packages/web/app/_components/latest-projects.tsx
@@ -25,7 +25,7 @@ export function LatestProjects({ projects }: { projects: Projects }) {
         {projects.slice(offset, offset + pageSize).map((item) => (
           <Link
             key={item.project.id}
-            href={`/${item.team.slug}/${item.project.slug}/default`} // TODO: deal with multiple envs
+            href={`/${item.team.slug}/${item.project.slug}`}
             className="flex flex-col items-start gap-2 rounded-md border p-4 text-left text-sm transition-all hover:bg-accent"
           >
             <div className="flex w-full flex-col gap-1">

--- a/packages/web/app/_components/primary-header-item.tsx
+++ b/packages/web/app/_components/primary-header-item.tsx
@@ -64,8 +64,7 @@ export default function PrimaryHeaderItem({
 
   function onProjectSelected(project: schema.Project) {
     if (!team) return;
-    // TODO: Deal with multiple envs
-    router.push(`/${team.slug}/${project.slug}/default`);
+    router.push(`/${team.slug}/${project.slug}`);
   }
 
   function onNewProjectSelected() {
@@ -75,8 +74,7 @@ export default function PrimaryHeaderItem({
   function onNewProjectSuccess(project: schema.Project) {
     if (!team) return;
     router.refresh();
-    // TODO: Deal with multiple envs
-    router.push(`/${team.slug}/${project.slug}/default`);
+    router.push(`/${team.slug}/${project.slug}`);
   }
 
   const items: React.ReactNode[] = [

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -160,7 +160,7 @@ export default async function Page() {
                 {featuredProjects.map((item) => (
                   <Link
                     key={item.project.id}
-                    href={`/${item.team.slug}/${item.project.slug}/default`} // TODO: deal with multiple envs
+                    href={`/${item.team.slug}/${item.project.slug}`}
                     className="flex grow basis-1 flex-col items-start gap-2 rounded-md border p-4 text-left text-sm transition-all hover:bg-accent"
                   >
                     <div className="flex w-full flex-col gap-4">

--- a/packages/web/components/project-switcher.tsx
+++ b/packages/web/components/project-switcher.tsx
@@ -49,7 +49,7 @@ export default function ProjectSwitcher({
     <div className="flex items-center gap-1">
       {variant === "navigation" && team && selectedProject && (
         <Link
-          href={`/${team.slug}/${selectedProject.slug}/default`} // TODO: Handle multiple environments and read from local storage or session.
+          href={`/${team.slug}/${selectedProject.slug}`}
           className="underline-offset-2 hover:underline"
         >
           {selectedProject.name}

--- a/packages/web/components/table-menu.tsx
+++ b/packages/web/components/table-menu.tsx
@@ -158,10 +158,14 @@ export default function TableMenu({
         schemaPreset={schema}
         open={newDefFormOpen}
         onOpenChange={setNewDefFormOpen}
-        onSuccess={(team, project, def) => {
+        onSuccess={(selectedTeam, selectedProject, def) => {
           router.refresh();
-          // TODO: Handle multiple envs.
-          router.push(`/${team.slug}/${project.slug}/default/${def.slug}`);
+          router.push(
+            `/${selectedTeam.slug}/${selectedProject.slug}${env ? `/${env.slug}/${def.slug}` : `?table=${def.slug}`}`,
+          );
+          if (selectedProject.id === project?.id) {
+            void defsQuery.refetch();
+          }
         }}
       />
       <DropdownMenu>


### PR DESCRIPTION
This makes sure that old URLs from before env was part of the url will keep working. It's also a more general way of handing navigation to an environment which will allow us to do something more sophisticated like read the correct env from the user session.