### PR TITLE
add sql identifier escape util

### DIFF
--- a/packages/web/lib/utils.ts
+++ b/packages/web/lib/utils.ts
@@ -66,3 +66,14 @@ export const handleCopy = function (text: string, desc: string, toast: Toast) {
       });
     });
 };
+
+// Given a column name with escape characters, return the fomatted name.
+export const formatIdentifierName = function (name: string) {
+  return name
+    .replace(/^`/, "")
+    .replace(/`$/, "")
+    .replace(/^"/, "")
+    .replace(/"$/, "")
+    .replace(/^\[/, "")
+    .replace(/"\]/, "");
+};


### PR DESCRIPTION
This adds a util function that strips identifier characters off of strings.
Here are some relevant sqlite docs for more detail: https://www.sqlite.org/lang_keywords.html

Of note is that I didn't include the single quote, `'`, since anything escaped in that way become a string literal (not an identifier).  

