### PR TITLE
Handle unsupported chain deployments

### DIFF
--- a/packages/web/app/[team]/[project]/[env]/[table]/page.tsx
+++ b/packages/web/app/[team]/[project]/[env]/[table]/page.tsx
@@ -67,9 +67,7 @@ export default async function Deployments({
           />
         ) : (
           <div className="container max-w-2xl space-y-5">
-            {!deployment && (
-              <NeedsDeploy def={def} env={env} isAuthorized={isAuthorized} />
-            )}
+            <NeedsDeploy def={def} env={env} isAuthorized={isAuthorized} />
             <DefDetails name={def.name} schema={def.schema} />
           </div>
         )}

--- a/packages/web/app/[team]/[project]/[env]/[table]/page.tsx
+++ b/packages/web/app/[team]/[project]/[env]/[table]/page.tsx
@@ -64,6 +64,7 @@ export default async function Deployments({
             environment={env}
             defData={def}
             deploymentData={deployment}
+            isAuthorized={isAuthorized}
           />
         ) : (
           <div className="container max-w-2xl space-y-5">

--- a/packages/web/app/table/[name]/page.tsx
+++ b/packages/web/app/table/[name]/page.tsx
@@ -1,13 +1,9 @@
-import {
-  ApiError,
-  type Table as TblTable,
-  Validator,
-  helpers,
-} from "@tableland/sdk";
+import { type Table as TblTable, Validator, helpers } from "@tableland/sdk";
 import { getSession } from "@tableland/studio-api";
 import { cookies, headers } from "next/headers";
 import Table from "@/components/table";
 import TableWrapper from "@/components/table-wrapper";
+import { ensureError } from "@/lib/ensure-error";
 
 export default async function TablePage({
   params,
@@ -37,30 +33,19 @@ export default async function TablePage({
     );
   }
 
-  const validator = new Validator({
-    baseUrl: helpers.getBaseUrl(chainId),
-  });
-
   let tablelandTable: TblTable;
   try {
+    const validator = new Validator({
+      baseUrl: helpers.getBaseUrl(chainId),
+    });
     tablelandTable = await validator.getTableById({
       chainId,
       tableId,
     });
   } catch (err) {
-    if (err instanceof ApiError && err.status === 404) {
-      return (
-        <div className="p-4">
-          <p>
-            Table id {tableId} not found on chain {chainId}.
-          </p>
-        </div>
-      );
-    }
-    console.error("Error getting table by id:", { err });
     return (
       <div className="p-4">
-        <p>Error getting table by id</p>
+        <p>Error getting table by id: {ensureError(err).message}</p>
       </div>
     );
   }

--- a/packages/web/components/table.tsx
+++ b/packages/web/components/table.tsx
@@ -11,6 +11,7 @@ import {
   Workflow,
 } from "lucide-react";
 import Link from "next/link";
+import { type RouterOutputs } from "@tableland/studio-api";
 import { DataTable } from "./data-table";
 import {
   MetricCard,
@@ -43,6 +44,7 @@ interface Props {
   environment?: schema.Environment;
   defData?: DefData;
   deploymentData?: DeploymentData;
+  isAuthorized: RouterOutputs["teams"]["isAuthorized"];
 }
 
 interface DefData {
@@ -68,6 +70,7 @@ export default async function Table({
   environment,
   defData,
   deploymentData,
+  isAuthorized,
 }: Props) {
   const chain = chainsMap.get(chainId);
   const blockExplorer = blockExplorers.get(chainId);
@@ -107,12 +110,13 @@ export default async function Table({
             </AlertTitle>
             <AlertDescription>
               <p>{error.message}</p>
-              {error.message.includes("cannot use unsupported chain") && (
-                <p>
-                  You should undeploy this table and redeploy it to a supported
-                  chain.
-                </p>
-              )}
+              {isAuthorized &&
+                error.message.includes("cannot use unsupported chain") && (
+                  <p>
+                    You should undeploy this table and redeploy it to a
+                    supported chain.
+                  </p>
+                )}
             </AlertDescription>
           </Alert>
         )}

--- a/packages/web/components/table.tsx
+++ b/packages/web/components/table.tsx
@@ -44,7 +44,7 @@ interface Props {
   environment?: schema.Environment;
   defData?: DefData;
   deploymentData?: DeploymentData;
-  isAuthorized: RouterOutputs["teams"]["isAuthorized"];
+  isAuthorized?: RouterOutputs["teams"]["isAuthorized"];
 }
 
 interface DefData {


### PR DESCRIPTION
There are two cases where this is relevant:

1. Viewing a tableland table at the `/table/<table id>` url
2. Viewing a table in the context of a project

In both cases, the table being loaded might be for a chain we no longer support.

In the first case, it's as simple as just displaying the error message that says "unsupported chain id". 

In the second case, we still need to display enough UI to convey the error message and also give the user a way to delete the now-invalid deployment by un-deploying the table. The solution looks something like this:

![Tableland Studio · 12 02pm · 05-30](https://github.com/tablelandnetwork/studio/assets/528969/661f8d14-caf6-44db-a531-e6ddb9fb0c9d)
(Note, I forced the UI into an error state, so some of the surrounding data will not be what you expect in a real scenario)