### PR TITLE
Handle and display auto incrementing pks properly

### DIFF
--- a/packages/api/src/routers/deployments.ts
+++ b/packages/api/src/routers/deployments.ts
@@ -1,6 +1,7 @@
-import { type Store } from "@tableland/studio-store";
+import { unescapeSchema, type Store } from "@tableland/studio-store";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
+import { ApiError, type Table, Validator, helpers } from "@tableland/sdk";
 import {
   publicProcedure,
   createTRPCRouter,
@@ -25,6 +26,27 @@ export function deploymentsRouter(store: Store) {
         }),
       )
       .mutation(async ({ input }) => {
+        let tablelandTable: Table;
+        try {
+          const validator = new Validator({
+            baseUrl: helpers.getBaseUrl(input.chainId),
+          });
+          tablelandTable = await validator.getTableById({
+            chainId: input.chainId,
+            tableId: input.tableId,
+          });
+        } catch (err) {
+          if (err instanceof ApiError && err.status === 404) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: `Table id ${input.tableId} not found on chain ${input.chainId}.`,
+            });
+          }
+          throw internalError("Error getting table by id.", err);
+        }
+
+        const schema = unescapeSchema(tablelandTable.schema);
+
         const res = await store.deployments.recordDeployment({
           defId: input.defId,
           environmentId: input.environmentId,
@@ -35,6 +57,8 @@ export function deploymentsRouter(store: Store) {
           txnHash: input.txnHash,
           createdAt: input.createdAt,
         });
+        // TODO: Figure out how to submit both updates in one transaction
+        await store.defs.updateDef(input.defId, undefined, undefined, schema);
         return res;
       }),
     deleteDeployments: defAdminProcedure(store)

--- a/packages/store/src/api/auth.ts
+++ b/packages/store/src/api/auth.ts
@@ -44,6 +44,7 @@ export function auth(
       teamName: string,
       email?: string,
     ) {
+      const now = new Date().toISOString();
       const teamId = randomUUID();
       const sealed = await sealData(
         { email },
@@ -60,6 +61,8 @@ export function auth(
           personal: 1,
           name: teamName,
           slug: slugify(teamName),
+          createdAt: now,
+          updatedAt: now,
         })
         .toSQL();
       const { sql: teamMembershipsSql, params: teamMembershipsParams } = db

--- a/packages/store/src/api/teams.ts
+++ b/packages/store/src/api/teams.ts
@@ -163,7 +163,7 @@ export function initTeams(
           .all()
       ).map((r) => r.projectId);
 
-      // If the team has projects, delete them and all realated data
+      // If the team has projects, delete them and all related data
       if (teamProjectIds.length) {
         // projects
         const { sql: projectsSql, params: projectsParams } = db

--- a/packages/store/src/custom-types/index.ts
+++ b/packages/store/src/custom-types/index.ts
@@ -1,5 +1,6 @@
 import { type Schema as SDKSchema } from "@tableland/sdk";
 import { customType } from "drizzle-orm/sqlite-core";
+import { unescapeSchema } from "../helpers";
 
 export type Schema = SDKSchema;
 
@@ -10,7 +11,11 @@ export const schema = customType<{
     return "text";
   },
   fromDriver(value: unknown): Schema {
-    return value as Schema;
+    // We are already storing some Schema values that have escaped identifiers.
+    // This isn't ideal, but for now we'll just unescape all Schemas as we read
+    // them from the database.
+    const schema = value as Schema;
+    return unescapeSchema(schema);
   },
   toDriver(value: Schema): string {
     return JSON.stringify(value);

--- a/packages/store/src/helpers.ts
+++ b/packages/store/src/helpers.ts
@@ -27,6 +27,13 @@ export function setConstraint(
   }
 }
 
+export function isPrimaryKeyAutoIncrement(column: Schema["columns"][number]) {
+  return (
+    hasConstraint(column, "primary key autoincrement") ||
+    (hasConstraint(column, "primary key") && column.type === "integer")
+  );
+}
+
 export function generateCreateTableStatement(
   tableName: string,
   schema: Schema,

--- a/packages/web/app/table/[name]/page.tsx
+++ b/packages/web/app/table/[name]/page.tsx
@@ -1,6 +1,7 @@
 import { type Table as TblTable, Validator, helpers } from "@tableland/sdk";
 import { getSession } from "@tableland/studio-api";
 import { cookies, headers } from "next/headers";
+import { unescapeSchema } from "@tableland/studio-store";
 import Table from "@/components/table";
 import TableWrapper from "@/components/table-wrapper";
 import { ensureError } from "@/lib/ensure-error";
@@ -50,6 +51,8 @@ export default async function TablePage({
     );
   }
 
+  const schema = unescapeSchema(tablelandTable.schema);
+
   const createdAttr = tablelandTable.attributes?.find(
     (attr) => attr.traitType === "created",
   );
@@ -68,13 +71,13 @@ export default async function TablePage({
         displayName={params.name}
         chainId={chainId}
         tableId={tableId}
-        schema={tablelandTable.schema}
+        schema={schema}
         isAuthenticated={!!session.auth}
       >
         <Table
           chainId={chainId}
           createdAt={createdAt}
-          schema={tablelandTable.schema}
+          schema={schema}
           tableName={params.name}
           tableId={tableId}
         />

--- a/packages/web/components/def-columns.tsx
+++ b/packages/web/components/def-columns.tsx
@@ -35,7 +35,9 @@ export default function DefColumns({
       )}
       <TableBody>
         {columns.map((column, index) => {
-          const isPkAuto = hasConstraint(column, "primary key autoincrement");
+          const isPkAuto =
+            hasConstraint(column, "primary key autoincrement") ||
+            (column.type === "integer" && hasConstraint(column, "primary key"));
           return (
             <TableRow key={column.name}>
               <TableCell>

--- a/packages/web/components/def-columns.tsx
+++ b/packages/web/components/def-columns.tsx
@@ -1,5 +1,11 @@
 import { type Schema, hasConstraint } from "@tableland/studio-store";
-import { Check } from "lucide-react";
+import { ArrowUp01, Check } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
 import {
   Table,
   TableBody,
@@ -29,6 +35,7 @@ export default function DefColumns({
       )}
       <TableBody>
         {columns.map((column, index) => {
+          const isPkAuto = hasConstraint(column, "primary key autoincrement");
           return (
             <TableRow key={column.name}>
               <TableCell>
@@ -41,7 +48,23 @@ export default function DefColumns({
                 {hasConstraint(column, "not null") && <Check />}
               </TableCell>
               <TableCell align="center">
-                {hasConstraint(column, "primary key") && <Check />}
+                {(hasConstraint(column, "primary key") || isPkAuto) && (
+                  <div className="flex items-center justify-center gap-2">
+                    <Check />
+                    {isPkAuto && (
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <ArrowUp01 className="opacity-30 hover:opacity-100" />
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            Primary key is auto-incrementing
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    )}
+                  </div>
+                )}
               </TableCell>
               <TableCell align="center">
                 {hasConstraint(column, "unique") && <Check />}

--- a/packages/web/components/def-columns.tsx
+++ b/packages/web/components/def-columns.tsx
@@ -1,4 +1,8 @@
-import { type Schema, hasConstraint } from "@tableland/studio-store";
+import {
+  type Schema,
+  hasConstraint,
+  isPrimaryKeyAutoIncrement,
+} from "@tableland/studio-store";
 import { ArrowUp01, Check } from "lucide-react";
 import {
   Tooltip,
@@ -35,9 +39,7 @@ export default function DefColumns({
       )}
       <TableBody>
         {columns.map((column, index) => {
-          const isPkAuto =
-            hasConstraint(column, "primary key autoincrement") ||
-            (column.type === "integer" && hasConstraint(column, "primary key"));
+          const isPkAuto = isPrimaryKeyAutoIncrement(column);
           return (
             <TableRow key={column.name}>
               <TableCell>

--- a/packages/web/components/new-def-form.tsx
+++ b/packages/web/components/new-def-form.tsx
@@ -128,31 +128,12 @@ export default function NewDefForm({
     },
   });
 
-  const { handleSubmit, register, control, setError } = form;
+  const { handleSubmit, control, setError } = form;
 
   const { fields: columnFields } = useFieldArray({
     control,
     name: "columns",
   });
-
-  const addColumn = () => {
-    form.setValue("columns", [
-      ...form.getValues("columns"),
-      {
-        id: new Date().getTime().toString(),
-        name: "",
-        type: "integer",
-        notNull: false,
-        primaryKey: false,
-        unique: false,
-      },
-    ]);
-  };
-
-  const removeColumn = (index: number) => {
-    const cols = [...form.getValues("columns")];
-    form.setValue("columns", cols.toSpliced(index, 1));
-  };
 
   const handleTeamSelected = (team: schema.Team) => {
     setTeam(team);
@@ -303,14 +284,7 @@ export default function NewDefForm({
                   <FormItem>
                     <FormLabel>Columns</FormLabel>
                     <FormControl>
-                      <Columns
-                        columns={columnFields}
-                        control={control}
-                        register={register}
-                        addColumn={addColumn}
-                        removeColumn={removeColumn}
-                        {...field}
-                      />
+                      <Columns columns={columnFields} form={form} {...field} />
                     </FormControl>
                     <FormDescription>
                       Specify at least one column for your definition.


### PR DESCRIPTION
There is a Tableland quirk where, if you create an `Integer` column with a `primary key` constraint, it ends up also with an `autoincrement` modifier once it is materialized on Tableland. We can't specify the `autoincrement` part of `integer primary key autoincrement` in our `create` statement or else we get a syntax error... But when we ask the validator for information about a table, while importing a table, for example, `integer primary key autoincrement` is the constraint information that comes back.

This PR correctly deals with this situation for `Schema` data that is created by Studio and hasn't been deployed to Tableland as well as `Scheama`s that are imported from existing Tableland tables. It provides informative UI so the user understands what is going on.

Create table definition view when a non-integer column is configured:
<img src="https://github.com/tablelandnetwork/studio/assets/528969/8f1f5073-8dfc-4aba-a824-989d8dc917fb" width=500 />

Create table definition when an integer column is configured:
<img src="https://github.com/tablelandnetwork/studio/assets/528969/93418698-d344-473b-a983-457c07b89a23" width=500 />

Create table definition when an integer column is configured and you mouse over the icon:
<img src="https://github.com/tablelandnetwork/studio/assets/528969/de4c2a25-5833-4ccc-893a-281f4247af00" width=500 />

Table definition component using an icon to show the PK is auto-increment:
<img src="https://github.com/tablelandnetwork/studio/assets/528969/3ad193ea-40ab-43b2-aaba-20ad0dfa1f49" width=500 />

Hover state of table definition component using an icon to show the PK is auto-increment:
<img src="https://github.com/tablelandnetwork/studio/assets/528969/40f88821-f3a6-4f94-98a9-23e3b46262d7" width=500 />


