### PR TITLE
Expose environments in UX/UI

### DIFF
--- a/packages/api/src/routers/environments.ts
+++ b/packages/api/src/routers/environments.ts
@@ -83,7 +83,8 @@ export function environmentsRouter(store: Store) {
         const envId = ctx.session.projectEnvs?.[input.projectId];
         if (envId) {
           env = await store.environments.environmentById(envId);
-        } else {
+        }
+        if (!env) {
           const envs = await store.environments.getEnvironmentsByProjectId(
             input.projectId,
           );

--- a/packages/api/src/routers/environments.ts
+++ b/packages/api/src/routers/environments.ts
@@ -52,7 +52,16 @@ export function environmentsRouter(store: Store) {
         return environment;
       }),
     deleteEnvironment: environmentAdminProcedure(store).mutation(
-      async ({ input }) => {
+      async ({ input, ctx }) => {
+        const envs = await store.environments.getEnvironmentsByProjectId(
+          ctx.project.id,
+        );
+        if (envs.length === 1) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "Cannot delete the last environment in a project",
+          });
+        }
         await store.environments.deleteEnvironment(input.envId);
       },
     ),

--- a/packages/api/src/routers/environments.ts
+++ b/packages/api/src/routers/environments.ts
@@ -1,4 +1,4 @@
-import { type Store } from "@tableland/studio-store";
+import { type schema, type Store } from "@tableland/studio-store";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import {
@@ -72,18 +72,44 @@ export function environmentsRouter(store: Store) {
           input.projectId,
         );
       }),
-    userEnvironmentForProject: publicProcedure
+    environmentPreferenceForProject: publicProcedure
       .input(
         z.object({
           projectId: z.string().uuid(),
         }),
       )
       .query(async ({ input, ctx }) => {
-        // TODO: Check the user session for their last used env.
-        const envs = await store.environments.getEnvironmentsByProjectId(
-          input.projectId,
-        );
-        return envs[0];
+        let env: schema.Environment | undefined;
+        const envId = ctx.session.projectEnvs?.[input.projectId];
+        if (envId) {
+          env = await store.environments.environmentById(envId);
+        } else {
+          const envs = await store.environments.getEnvironmentsByProjectId(
+            input.projectId,
+          );
+          env = envs.length ? envs[0] : undefined;
+        }
+        if (!env) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "No environment preference found for this project",
+          });
+        }
+        return env;
+      }),
+    setEnvironmentPreferenceForProject: publicProcedure
+      .input(
+        z.object({
+          projectId: z.string().uuid(),
+          envId: z.string().uuid(),
+        }),
+      )
+      .mutation(async ({ input, ctx }) => {
+        ctx.session.projectEnvs = {
+          ...ctx.session.projectEnvs,
+          [input.projectId]: input.envId,
+        };
+        await ctx.session.save();
       }),
     environmentBySlug: publicProcedure
       .input(

--- a/packages/api/src/routers/environments.ts
+++ b/packages/api/src/routers/environments.ts
@@ -63,6 +63,19 @@ export function environmentsRouter(store: Store) {
           input.projectId,
         );
       }),
+    userEnvironmentForProject: publicProcedure
+      .input(
+        z.object({
+          projectId: z.string().uuid(),
+        }),
+      )
+      .query(async ({ input, ctx }) => {
+        // TODO: Check the user session for their last used env.
+        const envs = await store.environments.getEnvironmentsByProjectId(
+          input.projectId,
+        );
+        return envs[0];
+      }),
     environmentBySlug: publicProcedure
       .input(
         z.object({

--- a/packages/api/src/routers/projects.ts
+++ b/packages/api/src/routers/projects.ts
@@ -85,12 +85,8 @@ export function projectsRouter(store: Store) {
             ctx.teamId,
             input.name,
             input.description,
+            input.envNames.map((env) => env.name),
           );
-          // TODO: This is temporary to make sure all projects have a default environment.
-          await store.environments.createEnvironment({
-            projectId: project.id,
-            name: "default",
-          });
           return project;
         } catch (err) {
           throw internalError("Error creating project", err);

--- a/packages/api/src/session-data.ts
+++ b/packages/api/src/session-data.ts
@@ -18,12 +18,14 @@ export interface SessionData {
   nonce?: string;
   siweFields?: SiweFields;
   auth?: Auth;
+  projectEnvs?: Record<string, string>;
 }
 
 export const defaultSession: SessionData = {
   nonce: undefined,
   siweFields: undefined,
   auth: undefined,
+  projectEnvs: undefined,
 };
 
 export const sessionOptions: SessionOptions = {

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -288,7 +288,7 @@ export const environmentProcedure = (store: Store) =>
     .input(z.object({ envId: z.string().uuid() }))
     .use(async ({ ctx, input, next }) => {
       const { team, project } =
-        (await store.environments.environmentTeamAndProject(input.envId)) || {};
+        (await store.environments.environmentTeamAndProject(input.envId)) ?? {};
       if (!team) {
         throw new TRPCError({
           code: "NOT_FOUND",

--- a/packages/cli/src/commands/import-table.ts
+++ b/packages/cli/src/commands/import-table.ts
@@ -90,9 +90,8 @@ export const builder = function (args: Yargs) {
             chainId,
             tableId,
             projectId,
-            defName,
+            def: { name: defName, description: defDescription },
             environmentId,
-            defDescription,
           });
 
           logger.log(
@@ -210,9 +209,8 @@ export const builder = function (args: Yargs) {
               chainId,
               tableId,
               projectId,
-              defName,
+              def: { name: defName, description: defDescription },
               environmentId,
-              defDescription,
             });
           }
 

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -127,6 +127,8 @@ export const builder = function (args: Yargs) {
             teamId,
             name,
             description,
+            // TODO: Allow user to specify env names
+            envNames: [{ name: "default" }],
           });
 
           logger.log(JSON.stringify(result, null, 4));

--- a/packages/store/src/api/defs.ts
+++ b/packages/store/src/api/defs.ts
@@ -117,6 +117,15 @@ export function initDefs(db: DrizzleD1Database<typeof schema>, tbl: Database) {
       await tbl.batch(batch);
     },
 
+    defById: async function (defId: string) {
+      const res = await db
+        .select({ defs })
+        .from(defs)
+        .where(eq(defs.id, defId))
+        .get();
+      return res?.defs;
+    },
+
     defsByProjectId: async function (projectId: string) {
       const res = await db
         .select({ defs })

--- a/packages/store/src/api/environments.ts
+++ b/packages/store/src/api/environments.ts
@@ -1,18 +1,40 @@
 import { randomUUID } from "crypto";
 import { type Database } from "@tableland/sdk";
-import { eq, and } from "drizzle-orm";
+import { eq, and, ne } from "drizzle-orm";
 import { type DrizzleD1Database } from "drizzle-orm/d1";
 import * as schema from "../schema/index.js";
 import { slugify } from "../helpers.js";
 
 type Environment = schema.Environment;
 const environments = schema.environments;
+const deployments = schema.deployments;
+const teamProjects = schema.teamProjects;
+const teams = schema.teams;
 
 export function initEnvironments(
   db: DrizzleD1Database<typeof schema>,
   tbl: Database,
 ) {
   return {
+    nameAvailable: async function (
+      projectId: string,
+      name: string,
+      envId?: string,
+    ) {
+      const res = await db
+        .select()
+        .from(environments)
+        .where(
+          and(
+            eq(environments.projectId, projectId),
+            eq(environments.slug, slugify(name)),
+            envId ? ne(environments.id, envId) : undefined,
+          ),
+        )
+        .get();
+      return !res;
+    },
+
     createEnvironment: async function ({
       projectId,
       name,
@@ -30,25 +52,68 @@ export function initEnvironments(
         createdAt: now,
         updatedAt: now,
       };
-      const { sql, params } = db
-        .insert(environments)
-        .values(environment)
-        .toSQL();
-      await tbl.prepare(sql).bind(params).run();
+      await db.insert(environments).values(environment);
       return environment;
+    },
+
+    updateEnvironment: async function ({
+      id,
+      name,
+    }: {
+      id: string;
+      name: string;
+    }) {
+      const updatedAt = new Date().toISOString();
+      await db
+        .update(environments)
+        .set({ name, slug: slugify(name), updatedAt })
+        .where(eq(environments.id, id))
+        .run();
+      return await db
+        .select()
+        .from(environments)
+        .where(eq(environments.id, id))
+        .get();
+    },
+
+    deleteEnvironment: async function (id: string) {
+      const { sql: envsSql, params: envsParams } = db
+        .delete(environments)
+        .where(eq(environments.id, id))
+        .toSQL();
+      const { sql: deploymentsSql, params: deploymentsParams } = db
+        .delete(deployments)
+        .where(eq(deployments.environmentId, id))
+        .toSQL();
+      const batch = [
+        tbl.prepare(envsSql).bind(envsParams),
+        tbl.prepare(deploymentsSql).bind(deploymentsParams),
+      ];
+      await tbl.batch(batch);
+    },
+
+    environmentTeam: async function (id: string) {
+      const res = await db
+        .select({ teams })
+        .from(environments)
+        .innerJoin(
+          teamProjects,
+          eq(environments.projectId, teamProjects.projectId),
+        )
+        .innerJoin(teams, eq(teamProjects.teamId, teams.id))
+        .where(eq(environments.id, id))
+        .get();
+      return res?.teams;
     },
 
     getEnvironmentsByProjectId: async function (
       projectId: string,
     ): Promise<Environment[]> {
-      const { sql, params } = db
+      return await db
         .select()
         .from(environments)
         .where(eq(environments.projectId, projectId))
-        .toSQL();
-
-      const res = await tbl.prepare(sql).bind(params).all();
-      return res.results as Environment[];
+        .all();
     },
 
     environmentBySlug: async function (projectId: string, slug: string) {

--- a/packages/store/src/api/environments.ts
+++ b/packages/store/src/api/environments.ts
@@ -8,6 +8,7 @@ import { slugify } from "../helpers.js";
 type Environment = schema.Environment;
 const environments = schema.environments;
 const deployments = schema.deployments;
+const projects = schema.projects;
 const teamProjects = schema.teamProjects;
 const teams = schema.teams;
 
@@ -92,18 +93,16 @@ export function initEnvironments(
       await tbl.batch(batch);
     },
 
-    environmentTeam: async function (id: string) {
+    environmentTeamAndProject: async function (id: string) {
       const res = await db
-        .select({ teams })
+        .select({ team: teams, project: projects })
         .from(environments)
-        .innerJoin(
-          teamProjects,
-          eq(environments.projectId, teamProjects.projectId),
-        )
+        .innerJoin(projects, eq(environments.projectId, projects.id))
+        .innerJoin(teamProjects, eq(projects.id, teamProjects.projectId))
         .innerJoin(teams, eq(teamProjects.teamId, teams.id))
         .where(eq(environments.id, id))
         .get();
-      return res?.teams;
+      return res;
     },
 
     getEnvironmentsByProjectId: async function (

--- a/packages/store/src/api/environments.ts
+++ b/packages/store/src/api/environments.ts
@@ -105,6 +105,14 @@ export function initEnvironments(
       return res;
     },
 
+    environmentById: async function (id: string) {
+      return await db
+        .select()
+        .from(environments)
+        .where(eq(environments.id, id))
+        .get();
+    },
+
     getEnvironmentsByProjectId: async function (
       projectId: string,
     ): Promise<Environment[]> {

--- a/packages/store/src/api/projects.ts
+++ b/packages/store/src/api/projects.ts
@@ -43,6 +43,7 @@ export function initProjects(
       teamId: string,
       name: string,
       description: string,
+      envNames: string[],
     ) {
       const projectId = randomUUID();
       const slug = slugify(name);
@@ -63,9 +64,22 @@ export function initProjects(
         .insert(teamProjects)
         .values({ projectId, teamId, isOwner: 1 })
         .toSQL();
+      const envs: schema.Environment[] = envNames.map((name) => ({
+        id: randomUUID(),
+        projectId,
+        name,
+        slug: slugify(name),
+        createdAt: now,
+        updatedAt: now,
+      }));
+      const { sql: envsSql, params: envsParams } = db
+        .insert(environments)
+        .values(envs)
+        .toSQL();
       await tbl.batch([
         tbl.prepare(projectsSql).bind(projectsParams),
         tbl.prepare(teamProjectsSql).bind(teamProjectsParams),
+        tbl.prepare(envsSql).bind(envsParams),
       ]);
       return project;
     },

--- a/packages/store/src/api/projects.ts
+++ b/packages/store/src/api/projects.ts
@@ -218,7 +218,7 @@ export function initProjects(
         .where(
           and(eq(teamProjects.teamId, teamId), eq(teamProjects.isOwner, 1)),
         )
-        .orderBy(projects.name)
+        .orderBy(projects.slug)
         .all();
       const mapped = res.map((r) => r.project);
       return mapped;

--- a/packages/validators/src/common.ts
+++ b/packages/validators/src/common.ts
@@ -29,3 +29,5 @@ export const defNameSchema = z
     },
     { message: "Definition name is invalid." },
   );
+
+export const envNameSchema = z.object({ name: z.string().trim().min(1) });

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -1,4 +1,3 @@
-export { defNameSchema } from "./common.js";
 export * from "./validators/defs.js";
 export * from "./validators/envs.js";
 export * from "./validators/teams.js";

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -1,5 +1,6 @@
 export { defNameSchema } from "./common.js";
 export * from "./validators/defs.js";
+export * from "./validators/envs.js";
 export * from "./validators/teams.js";
 export * from "./validators/projects.js";
 export * from "./validators/auth.js";

--- a/packages/validators/src/restricted-slugs.ts
+++ b/packages/validators/src/restricted-slugs.ts
@@ -1,4 +1,12 @@
-export const restrictedTeamSlugs = ["api", "invite", "sql-log", "table", "def"];
+export const restrictedTeamSlugs = [
+  "api",
+  "invite",
+  "sql-log",
+  "table",
+  "def",
+  "dash",
+  "dashboard",
+];
 
 export const restrictedProjectSlugs = ["people", "settings"];
 

--- a/packages/validators/src/validators/defs.ts
+++ b/packages/validators/src/validators/defs.ts
@@ -68,3 +68,5 @@ export const updateDefApiSchema = z.object({
   name: defNameSchema.optional(),
   description: defDescriptionSchema.optional(),
 });
+
+export { defNameSchema };

--- a/packages/validators/src/validators/envs.ts
+++ b/packages/validators/src/validators/envs.ts
@@ -1,0 +1,3 @@
+import { z } from "zod";
+
+export const envNameSchema = z.object({ name: z.string().trim().min(1) });

--- a/packages/validators/src/validators/envs.ts
+++ b/packages/validators/src/validators/envs.ts
@@ -1,3 +1,3 @@
-import { z } from "zod";
+import { envNameSchema } from "../common.js";
 
-export const envNameSchema = z.object({ name: z.string().trim().min(1) });
+export { envNameSchema };

--- a/packages/validators/src/validators/projects.ts
+++ b/packages/validators/src/validators/projects.ts
@@ -21,6 +21,12 @@ export const projectNameAvailableSchema = z.object({
 export const newProjectSchema = z.object({
   name: projectNameSchema,
   description: projectDescriptionSchema,
+  envNames: z
+    .array(z.object({ name: z.string().trim().min(1) }))
+    .min(1)
+    .refine((names) => {
+      return new Set(names.map((val) => val.name)).size === names.length;
+    }, "Environment names must be unique."),
 });
 
 export const updateProjectSchema = z.object({

--- a/packages/validators/src/validators/projects.ts
+++ b/packages/validators/src/validators/projects.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { slugify } from "@tableland/studio-store";
 import { restrictedProjectSlugs } from "../restricted-slugs.js";
+import { envNameSchema } from "../common.js";
 
 const projectNameSchema = z
   .string()
@@ -22,7 +23,7 @@ export const newProjectSchema = z.object({
   name: projectNameSchema,
   description: projectDescriptionSchema,
   envNames: z
-    .array(z.object({ name: z.string().trim().min(1) }))
+    .array(envNameSchema)
     .min(1)
     .refine((names) => {
       return new Set(names.map((val) => val.name)).size === names.length;

--- a/packages/validators/src/validators/tables.ts
+++ b/packages/validators/src/validators/tables.ts
@@ -4,7 +4,11 @@ import { defNameSchema } from "../common.js";
 export const importTableSchema = z.object({
   chainId: z.coerce.number().gt(0),
   tableId: z.string().trim().min(1),
-  defName: defNameSchema,
-  defDescription: z.string().trim().min(1),
+  def: z
+    .object({
+      name: defNameSchema,
+      description: z.string().trim().min(1),
+    })
+    .or(z.string().uuid()),
   environmentId: z.string().trim(),
 });

--- a/packages/web/app/[team]/(team)/_components/new-project-button.tsx
+++ b/packages/web/app/[team]/(team)/_components/new-project-button.tsx
@@ -6,15 +6,18 @@ import { useRouter } from "next/navigation";
 import NewProjectForm from "@/components/new-project-form";
 import { Button } from "@/components/ui/button";
 
-export default function NewProjectButton({ team }: { team: schema.Team }) {
+export default function NewProjectButton({
+  team,
+  ...props
+}: { team: schema.Team } & React.ComponentProps<typeof Button>) {
   const router = useRouter();
 
   return (
     <NewProjectForm
       team={team}
       trigger={
-        <Button variant="ghost" className="ml-auto">
-          <Plus className=" mr-2" />
+        <Button variant="secondary" {...props}>
+          <Plus className="mr-1 size-5" />
           New Project
         </Button>
       }

--- a/packages/web/app/[team]/(team)/_components/sidebar.tsx
+++ b/packages/web/app/[team]/(team)/_components/sidebar.tsx
@@ -29,14 +29,14 @@ export function Sidebar() {
         <SidebarLink
           href={`/${teamQuery.data.slug}`}
           title="Projects"
-          Icon={Folders}
+          icon={Folders}
           selected={!selectedLayoutSegment}
         />
         {!teamQuery.data.personal && (
           <SidebarLink
             href={`/${teamQuery.data.slug}/people`}
             title="People"
-            Icon={Users}
+            icon={Users}
             selected={selectedLayoutSegment === "people"}
           />
         )}
@@ -44,7 +44,7 @@ export function Sidebar() {
           <SidebarLink
             href={`/${teamQuery.data.slug}/settings`}
             title="Settings"
-            Icon={Settings}
+            icon={Settings}
             selected={selectedLayoutSegment === "settings"}
           />
         )}

--- a/packages/web/app/[team]/(team)/_components/sidebar.tsx
+++ b/packages/web/app/[team]/(team)/_components/sidebar.tsx
@@ -25,7 +25,7 @@ export function Sidebar() {
   }
 
   return (
-    <SidebarContainer>
+    <SidebarContainer className="p-3">
       <SidebarSection>
         <Link href={`/${teamQuery.data.slug}`}>
           <Button

--- a/packages/web/app/[team]/(team)/_components/sidebar.tsx
+++ b/packages/web/app/[team]/(team)/_components/sidebar.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import { Folders, Settings, Users } from "lucide-react";
-import Link from "next/link";
 import { useParams, useSelectedLayoutSegment } from "next/navigation";
 import { skipToken } from "@tanstack/react-query";
-import { Button } from "@/components/ui/button";
 import { api } from "@/trpc/react";
 import { SidebarContainer, SidebarSection } from "@/components/sidebar";
+import SidebarLink from "@/components/sidebar-link";
 
 export function Sidebar() {
   const { team: teamSlug } = useParams<{
@@ -25,42 +24,29 @@ export function Sidebar() {
   }
 
   return (
-    <SidebarContainer className="p-3">
+    <SidebarContainer>
       <SidebarSection>
-        <Link href={`/${teamQuery.data.slug}`}>
-          <Button
-            variant={!selectedLayoutSegment ? "secondary" : "ghost"}
-            className="w-full justify-start gap-x-2 pl-1"
-          >
-            <Folders className="size-5" />
-            Projects
-          </Button>
-        </Link>
+        <SidebarLink
+          href={`/${teamQuery.data.slug}`}
+          title="Projects"
+          Icon={Folders}
+          selected={!selectedLayoutSegment}
+        />
         {!teamQuery.data.personal && (
-          <Link href={`/${teamQuery.data.slug}/people`}>
-            <Button
-              variant={
-                selectedLayoutSegment === "people" ? "secondary" : "ghost"
-              }
-              className="w-full justify-start gap-x-2 pl-1"
-            >
-              <Users className="size-5" />
-              People
-            </Button>
-          </Link>
+          <SidebarLink
+            href={`/${teamQuery.data.slug}/people`}
+            title="People"
+            Icon={Users}
+            selected={selectedLayoutSegment === "people"}
+          />
         )}
         {isAuthorizedQuery.data && (
-          <Link href={`/${teamQuery.data.slug}/settings`}>
-            <Button
-              variant={
-                selectedLayoutSegment === "settings" ? "secondary" : "ghost"
-              }
-              className="w-full justify-start gap-x-2 pl-1"
-            >
-              <Settings className="size-5" />
-              Settings
-            </Button>
-          </Link>
+          <SidebarLink
+            href={`/${teamQuery.data.slug}/settings`}
+            title="Settings"
+            Icon={Settings}
+            selected={selectedLayoutSegment === "settings"}
+          />
         )}
       </SidebarSection>
     </SidebarContainer>

--- a/packages/web/app/[team]/(team)/_components/sidebar.tsx
+++ b/packages/web/app/[team]/(team)/_components/sidebar.tsx
@@ -32,7 +32,7 @@ export function Sidebar() {
             variant={!selectedLayoutSegment ? "secondary" : "ghost"}
             className="w-full justify-start gap-x-2 pl-1"
           >
-            <Folders />
+            <Folders className="size-5" />
             Projects
           </Button>
         </Link>
@@ -44,7 +44,7 @@ export function Sidebar() {
               }
               className="w-full justify-start gap-x-2 pl-1"
             >
-              <Users />
+              <Users className="size-5" />
               People
             </Button>
           </Link>
@@ -57,7 +57,7 @@ export function Sidebar() {
               }
               className="w-full justify-start gap-x-2 pl-1"
             >
-              <Settings />
+              <Settings className="size-5" />
               Settings
             </Button>
           </Link>

--- a/packages/web/app/[team]/(team)/layout.tsx
+++ b/packages/web/app/[team]/(team)/layout.tsx
@@ -10,7 +10,7 @@ export default async function LayoutTeam({
       <div className="sticky top-[3.55rem] h-[calc(100vh-3.55rem)] min-w-40 flex-shrink-0 overflow-y-auto overflow-x-hidden border-r border-[#080A1E] bg-card">
         <Sidebar />
       </div>
-      <div className="w-full">{children}</div>
+      <div className="flex w-full">{children}</div>
     </div>
   );
 }

--- a/packages/web/app/[team]/(team)/layout.tsx
+++ b/packages/web/app/[team]/(team)/layout.tsx
@@ -7,7 +7,7 @@ export default async function LayoutTeam({
 }) {
   return (
     <div className="flex flex-1 items-stretch">
-      <div className="sticky top-[3.55rem] h-[calc(100vh-3.55rem)] min-w-40 flex-shrink-0 overflow-y-auto overflow-x-hidden border-r border-[#080A1E] bg-card">
+      <div className="sticky top-[3.55rem] h-[calc(100vh-3.55rem)] w-52 flex-shrink-0 overflow-y-auto overflow-x-hidden border-r border-[#080A1E] bg-card">
         <Sidebar />
       </div>
       <div className="flex w-full">{children}</div>

--- a/packages/web/app/[team]/(team)/page.tsx
+++ b/packages/web/app/[team]/(team)/page.tsx
@@ -35,7 +35,7 @@ export default async function Projects({
 
   return (
     <main className="container flex max-w-5xl flex-1 flex-col items-stretch gap-4 p-4">
-      <div className="flex items-center">
+      <div className="flex items-end">
         <h1 className="text-3xl font-medium">{team.name} projects</h1>
         {authorized && <NewProjectButton team={team} className="ml-auto" />}
       </div>

--- a/packages/web/app/[team]/(team)/settings/_components/edit-team.tsx
+++ b/packages/web/app/[team]/(team)/settings/_components/edit-team.tsx
@@ -5,7 +5,7 @@ import { type schema } from "@tableland/studio-store";
 import { updateTeamSchema } from "@tableland/studio-validators";
 import { useForm } from "react-hook-form";
 import { type z } from "zod";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { skipToken } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { Loader2 } from "lucide-react";
@@ -37,6 +37,10 @@ export default function EditTeam({
       name: team.name,
     },
   });
+
+  useEffect(() => {
+    form.reset({ name: team.name });
+  }, [team, form]);
 
   const nameAvailable = api.teams.nameAvailable.useQuery(
     query !== team.name ? { teamId: team.id, name: query } : skipToken,

--- a/packages/web/app/[team]/[project]/[env]/[table]/_components/needs-deploy.tsx
+++ b/packages/web/app/[team]/[project]/[env]/[table]/_components/needs-deploy.tsx
@@ -9,7 +9,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { cn } from "@/lib/utils";
 
 export default async function NeedsDeploy({
   def,

--- a/packages/web/app/[team]/[project]/[env]/[table]/_components/needs-deploy.tsx
+++ b/packages/web/app/[team]/[project]/[env]/[table]/_components/needs-deploy.tsx
@@ -23,13 +23,9 @@ export default async function NeedsDeploy({
   return (
     <Card>
       <CardHeader>
-        <div className="flex items-center gap-2 text-destructive">
-          <AlertCircle
-            className={cn(!isAuthorized && "text-muted-foreground")}
-          />
-          <CardTitle className={cn(!isAuthorized && "text-foreground")}>
-            Table undeployed
-          </CardTitle>
+        <div className="flex items-center gap-2">
+          <AlertCircle />
+          <CardTitle>Table undeployed</CardTitle>
         </div>
         <CardDescription>
           Table definition {def.name} has has not yet been deployed to

--- a/packages/web/app/[team]/[project]/[env]/page.tsx
+++ b/packages/web/app/[team]/[project]/[env]/page.tsx
@@ -54,20 +54,22 @@ export default async function Deployments({
   }, new Set<boolean | undefined>());
 
   return (
-    <main className="m-4 flex flex-1 flex-col justify-center">
-      <h1 className="text-3xl font-medium">{project.name}</h1>
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <p className="line-clamp-1 max-w-md text-muted-foreground">
-              {project.description}
-            </p>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p className="max-w-xs">{project.description}</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+    <main className="m-4 flex flex-1 flex-col justify-center gap-y-4">
+      <div>
+        <h1 className="text-3xl font-medium">{project.name}</h1>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <p className="line-clamp-1 max-w-md text-muted-foreground">
+                {project.description}
+              </p>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p className="max-w-xs">{project.description}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
       <div className="m-auto grid max-w-4xl items-start justify-center gap-4 md:grid-cols-2">
         {chainTypes.size > 1 && (
           <div className="col-span-2 grid gap-4">

--- a/packages/web/app/[team]/[project]/[env]/page.tsx
+++ b/packages/web/app/[team]/[project]/[env]/page.tsx
@@ -97,7 +97,7 @@ export default async function Deployments({
             <CardHeader>
               <div className="flex items-center gap-2">
                 <Table2 className="text-muted-foreground" />
-                <CardTitle>Tables</CardTitle>
+                <CardTitle>Definitions</CardTitle>
               </div>
             </CardHeader>
             <CardContent className="text-center">
@@ -106,7 +106,7 @@ export default async function Deployments({
               </p>
             </CardContent>
             <CardFooter className="justify-center text-sm text-muted-foreground">
-              Tables deployed
+              Deployed to Tableland
             </CardFooter>
           </Card>
           <Card>
@@ -175,8 +175,7 @@ export default async function Deployments({
                 <CardTitle>SQL Logs</CardTitle>
               </div>
               <CardDescription>
-                Logs for all write operations to all deployed tables in your
-                project.
+                Logs for all write operations to all tables in your project.
               </CardDescription>
             </CardHeader>
             <CardContent>

--- a/packages/web/app/[team]/[project]/_components/sidebar.tsx
+++ b/packages/web/app/[team]/[project]/_components/sidebar.tsx
@@ -131,7 +131,7 @@ export function Sidebar() {
       </SidebarSection>
       <SidebarSection>
         <div className="flex items-center gap-2">
-          <h3 className="text-xl font-semibold text-muted-foreground">
+          <h3 className="text-base font-medium text-muted-foreground">
             Tables
           </h3>
           {!!isAuthorizedQuery.data && (
@@ -172,7 +172,7 @@ export function Sidebar() {
       {!!isAuthorizedQuery.data && (
         <SidebarSection className="sticky bottom-0 bg-card p-0">
           <div className="flex flex-col gap-3 p-3">
-            <h3 className="text-xl font-semibold text-muted-foreground">
+            <h3 className="text-base font-medium text-muted-foreground">
               Project
             </h3>
             <SidebarLink

--- a/packages/web/app/[team]/[project]/_components/sidebar.tsx
+++ b/packages/web/app/[team]/[project]/_components/sidebar.tsx
@@ -123,7 +123,7 @@ export function Sidebar() {
 
   return (
     <SidebarContainer>
-      <SidebarSection className="px-3 pt-3">
+      <SidebarSection>
         <Link
           href={`/${teamQuery.data.slug}/${projectQuery.data.slug}/${linkEnv.slug}`}
         >
@@ -140,17 +140,13 @@ export function Sidebar() {
           </Button>
         </Link>
       </SidebarSection>
-      <SidebarSection className={cn("px-3", !isAuthorizedQuery.data && "pb-3")}>
-        <div className="flex items-center gap-2 pl-1">
-          <h2 className="text-base font-medium text-muted-foreground">
-            Tables
-          </h2>
+      <SidebarSection>
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-medium text-muted-foreground">Tables</h2>
           {!!isAuthorizedQuery.data && (
             <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" className="ml-auto">
-                  <Ellipsis className="size-5" />
-                </Button>
+              <DropdownMenuTrigger className="ml-auto text-muted-foreground hover:text-foreground">
+                <Ellipsis className="size-5" />
               </DropdownMenuTrigger>
               <DropdownMenuContent>
                 <DropdownMenuItem onSelect={() => setNewDefOpen(true)}>
@@ -196,8 +192,11 @@ export function Sidebar() {
         })}
       </SidebarSection>
       {!!isAuthorizedQuery.data && (
-        <SidebarSection className="sticky bottom-0 bg-card">
-          <div className="px-3 pb-3">
+        <SidebarSection className="sticky bottom-0 bg-card p-0">
+          <div className="flex flex-col gap-3 p-3">
+            <h2 className="text-sm font-medium text-muted-foreground">
+              Project
+            </h2>
             <Link
               href={`/${teamQuery.data.slug}/${projectQuery.data.slug}/settings`}
             >

--- a/packages/web/app/[team]/[project]/_components/sidebar.tsx
+++ b/packages/web/app/[team]/[project]/_components/sidebar.tsx
@@ -54,11 +54,12 @@ export function Sidebar() {
       : skipToken,
   );
 
-  const userEnvForProject = api.environments.userEnvironmentForProject.useQuery(
-    projectQuery.data ? { projectId: projectQuery.data.id } : skipToken,
-  );
+  const envPreference =
+    api.environments.environmentPreferenceForProject.useQuery(
+      projectQuery.data ? { projectId: projectQuery.data.id } : skipToken,
+    );
 
-  const linkEnv = env ?? userEnvForProject.data;
+  const linkEnv = env ?? envPreference.data;
 
   const defQuery = api.defs.defByProjectIdAndSlug.useQuery(
     projectQuery.data && defSlug

--- a/packages/web/app/[team]/[project]/_components/sidebar.tsx
+++ b/packages/web/app/[team]/[project]/_components/sidebar.tsx
@@ -123,7 +123,7 @@ export function Sidebar() {
     <SidebarContainer>
       <SidebarSection>
         <SidebarLink
-          Icon={LayoutDashboard}
+          icon={LayoutDashboard}
           title="Overview"
           href={`/${teamQuery.data.slug}/${projectQuery.data.slug}/${linkEnv.slug}`}
           selected={!defSlug && !!envSlug && envSlug === env?.slug}
@@ -160,7 +160,7 @@ export function Sidebar() {
           return (
             <SidebarLink
               key={def.id}
-              Icon={Table2}
+              icon={Table2}
               title={def.name}
               href={`/${teamQuery.data.slug}/${projectQuery.data.slug}/${linkEnv.slug}/${def.slug}`}
               selected={def.id === defQuery.data?.id}
@@ -176,7 +176,7 @@ export function Sidebar() {
               Project
             </h3>
             <SidebarLink
-              Icon={Settings}
+              icon={Settings}
               title="Settings"
               href={`/${teamQuery.data.slug}/${projectQuery.data.slug}/settings`}
               selected={selectedLayoutSegment === "settings"}

--- a/packages/web/app/[team]/[project]/_components/sidebar.tsx
+++ b/packages/web/app/[team]/[project]/_components/sidebar.tsx
@@ -186,9 +186,7 @@ export function Sidebar() {
                   <div
                     className={cn(
                       "ml-auto size-2 rounded-full",
-                      isAuthorizedQuery.data
-                        ? "bg-destructive"
-                        : "bg-foreground",
+                      isAuthorizedQuery.data ? "bg-primary" : "bg-foreground",
                     )}
                   />
                 )}

--- a/packages/web/app/[team]/[project]/_components/sidebar.tsx
+++ b/packages/web/app/[team]/[project]/_components/sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type schema } from "@tableland/studio-store";
-import { Import, LayoutDashboard, Plus, Settings, Table2 } from "lucide-react";
+import { Ellipsis, LayoutDashboard, Settings, Table2 } from "lucide-react";
 import Link from "next/link";
 import {
   useParams,
@@ -10,15 +10,15 @@ import {
 } from "next/navigation";
 import { skipToken } from "@tanstack/react-query";
 import { useState } from "react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { api } from "@/trpc/react";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { SidebarContainer, SidebarSection } from "@/components/sidebar";
 import ImportTableForm from "@/components/import-table-form";
 import NewDefForm from "@/components/new-def-form";
@@ -122,7 +122,7 @@ export function Sidebar() {
 
   return (
     <SidebarContainer>
-      <SidebarSection className="p-3">
+      <SidebarSection className="px-3 pt-3">
         <Link
           href={`/${teamQuery.data.slug}/${projectQuery.data.slug}/${linkEnv.slug}`}
         >
@@ -134,53 +134,39 @@ export function Sidebar() {
             }
             className="w-full justify-start gap-x-2 pl-1"
           >
-            <LayoutDashboard />
+            <LayoutDashboard className="size-5" />
             Overview
           </Button>
         </Link>
+      </SidebarSection>
+      <SidebarSection className="px-3">
         <div className="flex items-center gap-2 pl-1">
-          <Table2 className="shrink-0" />
-          <h2 className="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50">
+          <h2 className="text-base font-medium text-muted-foreground">
             Tables
           </h2>
           {!!isAuthorizedQuery.data && (
-            <>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="ml-auto"
-                      onClick={() => setNewDefOpen(true)}
-                    >
-                      <Plus className="size-5" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>New table</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => setImportTableOpen(true)}
-                    >
-                      <Import className="size-5" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>Import table</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="ml-auto">
+                  <Ellipsis className="size-5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem onSelect={() => setNewDefOpen(true)}>
+                  New table
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => setImportTableOpen(true)}>
+                  Import table
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
         </div>
+        {!defsQuery.data?.length && (
+          <span className="text-center text-sm italic opacity-50">
+            No tables
+          </span>
+        )}
         {defsQuery.data?.map((def) => {
           const deployment = deploymentsMapQuery.data?.get(def.id);
           return (
@@ -191,8 +177,9 @@ export function Sidebar() {
               <Button
                 key={def.id}
                 variant={def.id === defQuery.data?.id ? "secondary" : "ghost"}
-                className="w-full justify-start"
+                className="w-full justify-start gap-x-2 pl-1"
               >
+                <Table2 className="size-5 shrink-0" />
                 <span className={cn(!deployment && "mr-4")}>{def.name}</span>
                 {env && !deployment && (
                   <div
@@ -211,7 +198,7 @@ export function Sidebar() {
       </SidebarSection>
       {!!isAuthorizedQuery.data && (
         <SidebarSection className="sticky bottom-0 bg-card">
-          <div className="p-3">
+          <div className="px-3 pb-3">
             <Link
               href={`/${teamQuery.data.slug}/${projectQuery.data.slug}/settings`}
             >
@@ -221,7 +208,7 @@ export function Sidebar() {
                 }
                 className="w-full justify-start gap-x-2 pl-1"
               >
-                <Settings />
+                <Settings className="size-5" />
                 Settings
               </Button>
             </Link>

--- a/packages/web/app/[team]/[project]/_components/sidebar.tsx
+++ b/packages/web/app/[team]/[project]/_components/sidebar.tsx
@@ -131,7 +131,7 @@ export function Sidebar() {
       </SidebarSection>
       <SidebarSection>
         <div className="flex items-center gap-2">
-          <h3 className="text-base font-medium text-muted-foreground">
+          <h3 className="text-base font-medium tracking-wide text-muted-foreground">
             Definitions
           </h3>
           {!!isAuthorizedQuery.data && (
@@ -172,7 +172,7 @@ export function Sidebar() {
       {!!isAuthorizedQuery.data && (
         <SidebarSection className="sticky bottom-0 bg-card p-0">
           <div className="flex flex-col gap-3 p-3">
-            <h3 className="text-base font-medium text-muted-foreground">
+            <h3 className="text-base font-medium tracking-wide text-muted-foreground">
               Project
             </h3>
             <SidebarLink

--- a/packages/web/app/[team]/[project]/_components/sidebar.tsx
+++ b/packages/web/app/[team]/[project]/_components/sidebar.tsx
@@ -2,7 +2,6 @@
 
 import { type schema } from "@tableland/studio-store";
 import { Ellipsis, LayoutDashboard, Settings, Table2 } from "lucide-react";
-import Link from "next/link";
 import {
   useParams,
   useRouter,
@@ -16,12 +15,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
 import { api } from "@/trpc/react";
 import { SidebarContainer, SidebarSection } from "@/components/sidebar";
 import ImportTableForm from "@/components/import-table-form";
 import NewDefForm from "@/components/new-def-form";
+import SidebarLink from "@/components/sidebar-link";
 
 export function Sidebar() {
   const {
@@ -124,25 +122,18 @@ export function Sidebar() {
   return (
     <SidebarContainer>
       <SidebarSection>
-        <Link
+        <SidebarLink
+          Icon={LayoutDashboard}
+          title="Overview"
           href={`/${teamQuery.data.slug}/${projectQuery.data.slug}/${linkEnv.slug}`}
-        >
-          <Button
-            variant={
-              !defSlug && !!envSlug && envSlug === env?.slug
-                ? "secondary"
-                : "ghost"
-            }
-            className="w-full justify-start gap-x-2 pl-1"
-          >
-            <LayoutDashboard className="size-5" />
-            Overview
-          </Button>
-        </Link>
+          selected={!defSlug && !!envSlug && envSlug === env?.slug}
+        />
       </SidebarSection>
       <SidebarSection>
         <div className="flex items-center gap-2">
-          <h2 className="text-sm font-medium text-muted-foreground">Tables</h2>
+          <h3 className="text-xl font-semibold text-muted-foreground">
+            Tables
+          </h3>
           {!!isAuthorizedQuery.data && (
             <DropdownMenu>
               <DropdownMenuTrigger className="ml-auto text-muted-foreground hover:text-foreground">
@@ -167,44 +158,29 @@ export function Sidebar() {
         {defsQuery.data?.map((def) => {
           const deployment = deploymentsMapQuery.data?.get(def.id);
           return (
-            <Link
+            <SidebarLink
               key={def.id}
+              Icon={Table2}
+              title={def.name}
               href={`/${teamQuery.data.slug}/${projectQuery.data.slug}/${linkEnv.slug}/${def.slug}`}
-            >
-              <Button
-                key={def.id}
-                variant={def.id === defQuery.data?.id ? "secondary" : "ghost"}
-                className="w-full justify-start gap-x-2 pl-1"
-              >
-                <Table2 className="size-5 shrink-0" />
-                <span className={cn(!deployment && "mr-4")}>{def.name}</span>
-                {env && !deployment && isAuthorizedQuery.data && (
-                  <div className="ml-auto size-2 rounded-full bg-primary" />
-                )}
-              </Button>
-            </Link>
+              selected={def.id === defQuery.data?.id}
+              showIndicator={!!env && !deployment && !!isAuthorizedQuery.data}
+            />
           );
         })}
       </SidebarSection>
       {!!isAuthorizedQuery.data && (
         <SidebarSection className="sticky bottom-0 bg-card p-0">
           <div className="flex flex-col gap-3 p-3">
-            <h2 className="text-sm font-medium text-muted-foreground">
+            <h3 className="text-xl font-semibold text-muted-foreground">
               Project
-            </h2>
-            <Link
+            </h3>
+            <SidebarLink
+              Icon={Settings}
+              title="Settings"
               href={`/${teamQuery.data.slug}/${projectQuery.data.slug}/settings`}
-            >
-              <Button
-                variant={
-                  selectedLayoutSegment === "settings" ? "secondary" : "ghost"
-                }
-                className="w-full justify-start gap-x-2 pl-1"
-              >
-                <Settings className="size-5" />
-                Settings
-              </Button>
-            </Link>
+              selected={selectedLayoutSegment === "settings"}
+            />
           </div>
         </SidebarSection>
       )}

--- a/packages/web/app/[team]/[project]/_components/sidebar.tsx
+++ b/packages/web/app/[team]/[project]/_components/sidebar.tsx
@@ -140,7 +140,7 @@ export function Sidebar() {
           </Button>
         </Link>
       </SidebarSection>
-      <SidebarSection className="px-3">
+      <SidebarSection className={cn("px-3", !isAuthorizedQuery.data && "pb-3")}>
         <div className="flex items-center gap-2 pl-1">
           <h2 className="text-base font-medium text-muted-foreground">
             Tables

--- a/packages/web/app/[team]/[project]/_components/sidebar.tsx
+++ b/packages/web/app/[team]/[project]/_components/sidebar.tsx
@@ -132,7 +132,7 @@ export function Sidebar() {
       <SidebarSection>
         <div className="flex items-center gap-2">
           <h3 className="text-base font-medium text-muted-foreground">
-            Tables
+            Definitions
           </h3>
           {!!isAuthorizedQuery.data && (
             <DropdownMenu>
@@ -141,7 +141,7 @@ export function Sidebar() {
               </DropdownMenuTrigger>
               <DropdownMenuContent>
                 <DropdownMenuItem onSelect={() => setNewDefOpen(true)}>
-                  New table
+                  New definition
                 </DropdownMenuItem>
                 <DropdownMenuItem onSelect={() => setImportTableOpen(true)}>
                   Import table

--- a/packages/web/app/[team]/[project]/_components/sidebar.tsx
+++ b/packages/web/app/[team]/[project]/_components/sidebar.tsx
@@ -178,13 +178,8 @@ export function Sidebar() {
               >
                 <Table2 className="size-5 shrink-0" />
                 <span className={cn(!deployment && "mr-4")}>{def.name}</span>
-                {env && !deployment && (
-                  <div
-                    className={cn(
-                      "ml-auto size-2 rounded-full",
-                      isAuthorizedQuery.data ? "bg-primary" : "bg-foreground",
-                    )}
-                  />
+                {env && !deployment && isAuthorizedQuery.data && (
+                  <div className="ml-auto size-2 rounded-full bg-primary" />
                 )}
               </Button>
             </Link>

--- a/packages/web/app/[team]/[project]/layout.tsx
+++ b/packages/web/app/[team]/[project]/layout.tsx
@@ -7,7 +7,7 @@ export default async function ProjectLayout({
 }) {
   return (
     <div className="flex flex-1 items-stretch">
-      <div className="sticky top-[3.55rem] h-[calc(100vh-3.55rem)] min-w-40 flex-shrink-0 overflow-y-auto overflow-x-hidden border-r border-[#080A1E] bg-card">
+      <div className="sticky top-[3.55rem] h-[calc(100vh-3.55rem)] w-52 flex-shrink-0 overflow-y-auto overflow-x-hidden border-r border-[#080A1E] bg-card">
         <Sidebar />
       </div>
       <div className="w-full">{children}</div>

--- a/packages/web/app/[team]/[project]/page.tsx
+++ b/packages/web/app/[team]/[project]/page.tsx
@@ -1,5 +1,5 @@
 import { RedirectType, redirect } from "next/navigation";
-import { projectBySlug } from "@/lib/api-helpers";
+import { projectBySlug, teamBySlug } from "@/lib/api-helpers";
 import { api } from "@/trpc/server";
 
 export default async function Page({
@@ -11,7 +11,8 @@ export default async function Page({
 }) {
   const table =
     typeof searchParams.table === "string" ? searchParams.table : undefined;
-  const project = await projectBySlug(params.project);
+  const team = await teamBySlug(params.team);
+  const project = await projectBySlug(params.project, team.id);
   const env = await api.environments.environmentPreferenceForProject({
     projectId: project.id,
   });

--- a/packages/web/app/[team]/[project]/page.tsx
+++ b/packages/web/app/[team]/[project]/page.tsx
@@ -1,6 +1,8 @@
 import { RedirectType, redirect } from "next/navigation";
+import { projectBySlug } from "@/lib/api-helpers";
+import { api } from "@/trpc/server";
 
-export default function Page({
+export default async function Page({
   params,
   searchParams,
 }: {
@@ -9,11 +11,13 @@ export default function Page({
 }) {
   const table =
     typeof searchParams.table === "string" ? searchParams.table : undefined;
-  // TODO: Look up correct env in user session.
-  const env = "default";
+  const project = await projectBySlug(params.project);
+  const env = await api.environments.userEnvironmentForProject({
+    projectId: project.id,
+  });
   const path = table
-    ? `/${params.team}/${params.project}/${env}/${table}`
-    : `/${params.team}/${params.project}/${env}`;
+    ? `/${params.team}/${params.project}/${env.slug}/${table}`
+    : `/${params.team}/${params.project}/${env.slug}`;
 
   redirect(path, RedirectType.replace);
 }

--- a/packages/web/app/[team]/[project]/page.tsx
+++ b/packages/web/app/[team]/[project]/page.tsx
@@ -12,7 +12,7 @@ export default async function Page({
   const table =
     typeof searchParams.table === "string" ? searchParams.table : undefined;
   const project = await projectBySlug(params.project);
-  const env = await api.environments.userEnvironmentForProject({
+  const env = await api.environments.environmentPreferenceForProject({
     projectId: project.id,
   });
   const path = table

--- a/packages/web/app/[team]/[project]/settings/_components/edit-env.tsx
+++ b/packages/web/app/[team]/[project]/settings/_components/edit-env.tsx
@@ -37,11 +37,11 @@ export default function EditEnv({ team }: { team: schema.Team }) {
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      email: "",
+      name: "",
     },
   });
 
-  const email = form.watch("email");
+  const name = form.watch("name");
 
   function onNewInvite() {
     setShowForm(true);
@@ -58,7 +58,7 @@ export default function EditEnv({ team }: { team: schema.Team }) {
 
   useEffect(() => {
     if (showForm) {
-      form.setFocus("email", { shouldSelect: true });
+      form.setFocus("name", { shouldSelect: true });
     }
   }, [form, showForm]);
 
@@ -73,16 +73,16 @@ export default function EditEnv({ team }: { team: schema.Team }) {
           {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
           <form onSubmit={form.handleSubmit(onSubmit)} className="flex">
             <Avatar>
-              <AvatarFallback>{email.charAt(0)}</AvatarFallback>
+              <AvatarFallback>{name.charAt(0)}</AvatarFallback>
             </Avatar>
             <FormField
               control={form.control}
-              name="email"
+              name="name"
               render={({ field }) => (
                 <FormItem>
                   <FormControl>
                     <Input
-                      placeholder="Email address"
+                      placeholder="Environment name"
                       className="ml-4"
                       disabled={inviteEmails.isPending}
                       {...field}

--- a/packages/web/app/[team]/[project]/settings/_components/edit-env.tsx
+++ b/packages/web/app/[team]/[project]/settings/_components/edit-env.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { type schema } from "@tableland/studio-store";
+import { Loader2, Plus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { api } from "@/trpc/react";
+
+const formSchema = z.object({
+  name: z.string().trim().min(1),
+});
+
+export default function EditEnv({ team }: { team: schema.Team }) {
+  const router = useRouter();
+  const [showForm, setShowForm] = useState(false);
+  const inviteEmails = api.environments.newEnvironment.useMutation({
+    onSuccess: () => {
+      router.refresh();
+      setShowForm(false);
+      form.reset();
+    },
+  });
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      email: "",
+    },
+  });
+
+  const email = form.watch("email");
+
+  function onNewInvite() {
+    setShowForm(true);
+  }
+
+  function onSubmit(values: z.infer<typeof formSchema>) {
+    inviteEmails.mutate({ teamId: team.id, emails: [values.email] });
+  }
+
+  function onCancel() {
+    setShowForm(false);
+    form.reset();
+  }
+
+  useEffect(() => {
+    if (showForm) {
+      form.setFocus("email", { shouldSelect: true });
+    }
+  }, [form, showForm]);
+
+  return (
+    <>
+      {showForm && (
+        <Form {...form}>
+          {
+            // TODO: `form.handleSubmit` creates a floating promise, as a result the linter is complaining
+            //    we should figure out if this is ok or not and either change this or the lint config
+          }
+          {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+          <form onSubmit={form.handleSubmit(onSubmit)} className="flex">
+            <Avatar>
+              <AvatarFallback>{email.charAt(0)}</AvatarFallback>
+            </Avatar>
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <Input
+                      placeholder="Email address"
+                      className="ml-4"
+                      disabled={inviteEmails.isPending}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage className="ml-4" />
+                </FormItem>
+              )}
+            />
+            <Button
+              type="submit"
+              size="sm"
+              disabled={inviteEmails.isPending}
+              className="ml-auto"
+            >
+              {inviteEmails.isPending && (
+                <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+              )}
+              Submit
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={inviteEmails.isPending}
+              onClick={onCancel}
+              className="ml-2"
+            >
+              Cancel
+            </Button>
+          </form>
+        </Form>
+      )}
+      <Button
+        variant="outline"
+        className="self-start"
+        disabled={showForm}
+        onClick={onNewInvite}
+      >
+        <Plus className="mr-2" />
+        New Invite
+      </Button>
+    </>
+  );
+}

--- a/packages/web/app/[team]/[project]/settings/_components/edit-project.tsx
+++ b/packages/web/app/[team]/[project]/settings/_components/edit-project.tsx
@@ -5,7 +5,7 @@ import { type schema } from "@tableland/studio-store";
 import { updateProjectSchema } from "@tableland/studio-validators";
 import { useForm } from "react-hook-form";
 import { type z } from "zod";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { skipToken } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { Loader2 } from "lucide-react";
@@ -41,6 +41,10 @@ export default function EditProject({
       description: project.description,
     },
   });
+
+  useEffect(() => {
+    form.reset({ name: project.name, description: project.description });
+  }, [project, form]);
 
   const nameAvailable = api.projects.nameAvailable.useQuery(
     query !== project.name

--- a/packages/web/app/[team]/[project]/settings/_components/env.tsx
+++ b/packages/web/app/[team]/[project]/settings/_components/env.tsx
@@ -59,6 +59,10 @@ export default function Env({
     },
   });
 
+  useEffect(() => {
+    form.reset({ name: env.name });
+  }, [env, form]);
+
   function onEdit() {
     setShowForm(true);
   }

--- a/packages/web/app/[team]/[project]/settings/_components/env.tsx
+++ b/packages/web/app/[team]/[project]/settings/_components/env.tsx
@@ -41,13 +41,12 @@ export default function Env({
       : skipToken,
     { retry: false },
   );
-  const userEnvForProject = api.environments.userEnvironmentForProject.useQuery(
-    { projectId },
-  );
+  const envPreference =
+    api.environments.environmentPreferenceForProject.useQuery({ projectId });
   const updateEnv = api.environments.updateEnvironment.useMutation({
     onSuccess: () => {
       router.refresh();
-      void userEnvForProject.refetch();
+      void envPreference.refetch();
       setShowForm(false);
       form.reset();
     },

--- a/packages/web/app/[team]/[project]/settings/_components/env.tsx
+++ b/packages/web/app/[team]/[project]/settings/_components/env.tsx
@@ -1,0 +1,155 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { type schema } from "@tableland/studio-store";
+import { Loader2, Edit, Trash } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { skipToken } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@/components/ui/form";
+import { api } from "@/trpc/react";
+import InputWithCheck from "@/components/input-with-check";
+import { cn } from "@/lib/utils";
+
+const formSchema = z.object({
+  name: z.string().trim().min(1),
+});
+
+export default function Env({
+  env,
+  showDelete,
+  onDelete,
+  disabled,
+}: {
+  env: schema.Environment;
+  showDelete: boolean;
+  onDelete: () => void;
+  disabled?: boolean;
+}) {
+  const router = useRouter();
+  const [showForm, setShowForm] = useState(false);
+  const [query, setQuery] = useState(env.name);
+  const nameAvailable = api.environments.nameAvailable.useQuery(
+    query !== env.name
+      ? { projectId: env.projectId, name: query, envId: env.id }
+      : skipToken,
+    { retry: false },
+  );
+  const updateEnv = api.environments.updateEnvironment.useMutation({
+    onSuccess: () => {
+      router.refresh();
+      setShowForm(false);
+      form.reset();
+    },
+  });
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: env.name,
+    },
+  });
+
+  function onEdit() {
+    setShowForm(true);
+  }
+
+  function onSubmit(values: z.infer<typeof formSchema>) {
+    updateEnv.mutate({ envId: env.id, ...values });
+  }
+
+  function onCancel() {
+    setShowForm(false);
+    form.reset();
+  }
+
+  useEffect(() => {
+    if (showForm) {
+      form.setFocus("name", { shouldSelect: true });
+    }
+  }, [form, showForm]);
+
+  return (
+    <div className="group px-3 py-1 hover:bg-accent">
+      {showForm ? (
+        <Form {...form}>
+          <form
+            // TODO: `form.handleSubmit` creates a floating promise, as a result the linter is complaining
+            // we should figure out if this is ok or not and either change this or the lint config
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="flex items-center gap-x-3"
+          >
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <InputWithCheck
+                      placeholder="Environment name"
+                      disabled={updateEnv.isPending}
+                      updateQuery={setQuery}
+                      queryStatus={nameAvailable}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage className="ml-4" />
+                </FormItem>
+              )}
+            />
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={updateEnv.isPending}
+              onClick={onCancel}
+              className="ml-auto"
+            >
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={updateEnv.isPending}>
+              {updateEnv.isPending && (
+                <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+              )}
+              Save
+            </Button>
+          </form>
+        </Form>
+      ) : (
+        <div className="flex items-center">
+          <p className="text-sm">{env.name}</p>
+          {showDelete && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onDelete}
+              className="ml-auto opacity-10 group-hover:opacity-100"
+              disabled={disabled}
+            >
+              <Trash />
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onEdit}
+            className={cn(
+              "opacity-10 group-hover:opacity-100",
+              !showDelete && "ml-auto",
+            )}
+            disabled={disabled}
+          >
+            <Edit />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/app/[team]/[project]/settings/_components/env.tsx
+++ b/packages/web/app/[team]/[project]/settings/_components/env.tsx
@@ -4,8 +4,9 @@ import { Loader2, Edit, Trash } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { z } from "zod";
+import { type z } from "zod";
 import { skipToken } from "@tanstack/react-query";
+import { envNameSchema } from "@tableland/studio-validators";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -17,10 +18,6 @@ import {
 import { api } from "@/trpc/react";
 import InputWithCheck from "@/components/input-with-check";
 import { cn } from "@/lib/utils";
-
-const formSchema = z.object({
-  name: z.string().trim().min(1),
-});
 
 export default function Env({
   env,
@@ -50,8 +47,8 @@ export default function Env({
     },
   });
 
-  const form = useForm<z.infer<typeof formSchema>>({
-    resolver: zodResolver(formSchema),
+  const form = useForm<z.infer<typeof envNameSchema>>({
+    resolver: zodResolver(envNameSchema),
     defaultValues: {
       name: env.name,
     },
@@ -61,7 +58,7 @@ export default function Env({
     setShowForm(true);
   }
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
+  function onSubmit(values: z.infer<typeof envNameSchema>) {
     updateEnv.mutate({ envId: env.id, ...values });
   }
 

--- a/packages/web/app/[team]/[project]/settings/_components/env.tsx
+++ b/packages/web/app/[team]/[project]/settings/_components/env.tsx
@@ -20,11 +20,13 @@ import InputWithCheck from "@/components/input-with-check";
 import { cn } from "@/lib/utils";
 
 export default function Env({
+  projectId,
   env,
   showDelete,
   onDelete,
   disabled,
 }: {
+  projectId: string;
   env: schema.Environment;
   showDelete: boolean;
   onDelete: () => void;
@@ -39,9 +41,13 @@ export default function Env({
       : skipToken,
     { retry: false },
   );
+  const userEnvForProject = api.environments.userEnvironmentForProject.useQuery(
+    { projectId },
+  );
   const updateEnv = api.environments.updateEnvironment.useMutation({
     onSuccess: () => {
       router.refresh();
+      void userEnvForProject.refetch();
       setShowForm(false);
       form.reset();
     },

--- a/packages/web/app/[team]/[project]/settings/_components/envs.tsx
+++ b/packages/web/app/[team]/[project]/settings/_components/envs.tsx
@@ -18,9 +18,11 @@ import {
 import { Button } from "@/components/ui/button";
 
 export default function Envs({
+  project,
   envs,
   disabled,
 }: {
+  project: schema.Project;
   envs: schema.Environment[];
   disabled?: boolean;
 }) {
@@ -29,9 +31,14 @@ export default function Envs({
     schema.Environment | undefined
   >();
 
+  const projectsEnvs = api.environments.projectEnvironments.useQuery({
+    projectId: project.id,
+  });
+
   const deleteEnv = api.environments.deleteEnvironment.useMutation({
     onSuccess: () => {
       router.refresh();
+      void projectsEnvs.refetch();
       setEnvToDelete(undefined);
     },
   });

--- a/packages/web/app/[team]/[project]/settings/_components/envs.tsx
+++ b/packages/web/app/[team]/[project]/settings/_components/envs.tsx
@@ -1,21 +1,104 @@
 "use client";
 
 import { type schema } from "@tableland/studio-store";
-import { Edit, Trash } from "lucide-react";
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import Env from "./env";
+import { api } from "@/trpc/react";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 
-export default function Envs({ envs }: { envs: schema.Environment[] }) {
+export default function Envs({
+  envs,
+  disabled,
+}: {
+  envs: schema.Environment[];
+  disabled?: boolean;
+}) {
+  const router = useRouter();
+  const [envToDelete, setEnvToDelete] = useState<
+    schema.Environment | undefined
+  >();
+
+  const deleteEnv = api.environments.deleteEnvironment.useMutation({
+    onSuccess: () => {
+      router.refresh();
+      setEnvToDelete(undefined);
+    },
+  });
+
+  const handleDelete = () => {
+    if (envToDelete) {
+      deleteEnv.mutate({ envId: envToDelete.id });
+    }
+  };
+
   return (
-    <div>
+    <div className="flex flex-col gap-y-0">
       {envs.map((env) => (
-        <div
+        <Env
           key={env.id}
-          className="group flex items-center gap-x-2 px-4 py-2 hover:bg-accent"
-        >
-          <p>{env.name}</p>
-          <Trash className="ml-auto opacity-10 group-hover:opacity-100" />
-          <Edit className="opacity-10 group-hover:opacity-100" />
-        </div>
+          env={env}
+          showDelete={envs.length > 1}
+          onDelete={() => setEnvToDelete(env)}
+          disabled={disabled}
+        />
       ))}
+      <Dialog
+        open={!!envToDelete}
+        onOpenChange={(open) => !open && setEnvToDelete(undefined)}
+      >
+        <DialogContent
+          closeDisabled={deleteEnv.isPending}
+          onPointerDownOutside={
+            deleteEnv.isPending ? (e) => e.preventDefault() : undefined
+          }
+          onEscapeKeyDown={
+            deleteEnv.isPending ? (e) => e.preventDefault() : undefined
+          }
+        >
+          <DialogHeader>
+            <DialogTitle>Delete environment {envToDelete?.name}?</DialogTitle>
+            <DialogDescription>
+              This action cannot be undone. All data related to this environment
+              will be deleted from Studio&apos;s database. This includes all
+              records of table deployments in this environment. Any tables that
+              were created on Tableland for this environment will continue to
+              exist on Tableland, but Studio will not be aware of them.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button
+                type="button"
+                variant="secondary"
+                disabled={deleteEnv.isPending}
+              >
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleteEnv.isPending}
+            >
+              {deleteEnv.isPending && (
+                <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+              )}
+              Yes, delete environment
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/packages/web/app/[team]/[project]/settings/_components/envs.tsx
+++ b/packages/web/app/[team]/[project]/settings/_components/envs.tsx
@@ -35,15 +35,16 @@ export default function Envs({
     projectId: project.id,
   });
 
-  const userEnvForProject = api.environments.userEnvironmentForProject.useQuery(
-    { projectId: project.id },
-  );
+  const envPreference =
+    api.environments.environmentPreferenceForProject.useQuery({
+      projectId: project.id,
+    });
 
   const deleteEnv = api.environments.deleteEnvironment.useMutation({
     onSuccess: () => {
       router.refresh();
       void projectsEnvs.refetch();
-      void userEnvForProject.refetch();
+      void envPreference.refetch();
       setEnvToDelete(undefined);
     },
   });

--- a/packages/web/app/[team]/[project]/settings/_components/envs.tsx
+++ b/packages/web/app/[team]/[project]/settings/_components/envs.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { type schema } from "@tableland/studio-store";
+import { Edit, Trash } from "lucide-react";
+
+export default function Envs({ envs }: { envs: schema.Environment[] }) {
+  return (
+    <div>
+      {envs.map((env) => (
+        <div
+          key={env.id}
+          className="group flex items-center gap-x-2 px-4 py-2 hover:bg-accent"
+        >
+          <p>{env.name}</p>
+          <Trash className="ml-auto opacity-10 group-hover:opacity-100" />
+          <Edit className="opacity-10 group-hover:opacity-100" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/app/[team]/[project]/settings/_components/envs.tsx
+++ b/packages/web/app/[team]/[project]/settings/_components/envs.tsx
@@ -35,10 +35,15 @@ export default function Envs({
     projectId: project.id,
   });
 
+  const userEnvForProject = api.environments.userEnvironmentForProject.useQuery(
+    { projectId: project.id },
+  );
+
   const deleteEnv = api.environments.deleteEnvironment.useMutation({
     onSuccess: () => {
       router.refresh();
       void projectsEnvs.refetch();
+      void userEnvForProject.refetch();
       setEnvToDelete(undefined);
     },
   });
@@ -54,6 +59,7 @@ export default function Envs({
       {envs.map((env) => (
         <Env
           key={env.id}
+          projectId={project.id}
           env={env}
           showDelete={envs.length > 1}
           onDelete={() => setEnvToDelete(env)}

--- a/packages/web/app/[team]/[project]/settings/_components/new-env.tsx
+++ b/packages/web/app/[team]/[project]/settings/_components/new-env.tsx
@@ -6,8 +6,9 @@ import { Loader2, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { z } from "zod";
+import { type z } from "zod";
 import { skipToken } from "@tanstack/react-query";
+import { envNameSchema } from "@tableland/studio-validators";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -18,10 +19,6 @@ import {
 } from "@/components/ui/form";
 import { api } from "@/trpc/react";
 import InputWithCheck from "@/components/input-with-check";
-
-const formSchema = z.object({
-  name: z.string().trim().min(1),
-});
 
 export default function NewEnv({
   project,
@@ -45,8 +42,8 @@ export default function NewEnv({
     },
   });
 
-  const form = useForm<z.infer<typeof formSchema>>({
-    resolver: zodResolver(formSchema),
+  const form = useForm<z.infer<typeof envNameSchema>>({
+    resolver: zodResolver(envNameSchema),
     defaultValues: {
       name: "",
     },
@@ -56,7 +53,7 @@ export default function NewEnv({
     setShowForm(true);
   }
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
+  function onSubmit(values: z.infer<typeof envNameSchema>) {
     newEnv.mutate({ projectId: project.id, ...values });
   }
 

--- a/packages/web/app/[team]/[project]/settings/page.tsx
+++ b/packages/web/app/[team]/[project]/settings/page.tsx
@@ -3,6 +3,7 @@ import { cache } from "react";
 import { OctagonAlert } from "lucide-react";
 import EditProject from "./_components/edit-project";
 import DeleteButton from "./_components/delete-button";
+import Envs from "./_components/envs";
 import { projectBySlug, teamBySlug } from "@/lib/api-helpers";
 import {
   Card,
@@ -24,6 +25,9 @@ export default async function ProjectSettings({
   const project = await projectBySlug(params.project, team.id);
   const authorization = await cache(api.teams.isAuthorized)({
     teamId: team.id,
+  });
+  const envs = await cache(api.environments.projectEnvironments)({
+    projectId: project.id,
   });
 
   if (!authorization) {
@@ -58,6 +62,19 @@ export default async function ProjectSettings({
             project={project}
             disabled={!isAdmin}
           />
+        </CardContent>
+      </Card>
+      <Card className={cn(!isAdmin && "opacity-50")}>
+        <CardHeader>
+          <CardTitle>Environments</CardTitle>
+          <CardDescription>
+            Environments are logical groups of tables. You could, for example,
+            use them to create &quot;staging&quot; and &quot;production&quot;
+            groups of tables.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Envs envs={envs} />
         </CardContent>
       </Card>
       <Card className={cn(!isAdmin && "opacity-50")}>

--- a/packages/web/app/[team]/[project]/settings/page.tsx
+++ b/packages/web/app/[team]/[project]/settings/page.tsx
@@ -71,7 +71,9 @@ export default async function ProjectSettings({
           <CardDescription>
             Environments are logical groups of tables. You could, for example,
             use them to create &quot;staging&quot; and &quot;production&quot;
-            groups of tables.
+            groups of tables. All of your project&apos;s table definitions are
+            available in each environment, but you can deploy those table
+            definitions to Tableland separately per environment.
           </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-y-4">

--- a/packages/web/app/[team]/[project]/settings/page.tsx
+++ b/packages/web/app/[team]/[project]/settings/page.tsx
@@ -69,11 +69,12 @@ export default async function ProjectSettings({
         <CardHeader>
           <CardTitle>Environments</CardTitle>
           <CardDescription>
-            Environments are logical groups of tables. You could, for example,
-            use them to create &quot;staging&quot; and &quot;production&quot;
-            groups of tables. All of your project&apos;s table definitions are
-            available in each environment, but you can deploy those table
-            definitions to Tableland separately per environment.
+            Environments are logical groups of definitions. You could, for
+            example, use them to create &quot;staging&quot; and
+            &quot;production&quot; groups of definitions. All of your
+            project&apos;s definitions are available in each environment, but
+            you can deploy those definitions to Tableland separately per
+            environment.
           </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-y-4">

--- a/packages/web/app/[team]/[project]/settings/page.tsx
+++ b/packages/web/app/[team]/[project]/settings/page.tsx
@@ -3,6 +3,7 @@ import { cache } from "react";
 import { OctagonAlert } from "lucide-react";
 import EditProject from "./_components/edit-project";
 import DeleteButton from "./_components/delete-button";
+import NewEnv from "./_components/new-env";
 import Envs from "./_components/envs";
 import { projectBySlug, teamBySlug } from "@/lib/api-helpers";
 import {
@@ -73,8 +74,9 @@ export default async function ProjectSettings({
             groups of tables.
           </CardDescription>
         </CardHeader>
-        <CardContent>
-          <Envs envs={envs} />
+        <CardContent className="flex flex-col gap-y-4">
+          <Envs envs={envs} disabled={!isAdmin} />
+          <NewEnv project={project} disabled={!isAdmin} />
         </CardContent>
       </Card>
       <Card className={cn(!isAdmin && "opacity-50")}>

--- a/packages/web/app/[team]/[project]/settings/page.tsx
+++ b/packages/web/app/[team]/[project]/settings/page.tsx
@@ -77,7 +77,7 @@ export default async function ProjectSettings({
           </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-y-4">
-          <Envs envs={envs} disabled={!isAdmin} />
+          <Envs project={project} envs={envs} disabled={!isAdmin} />
           <NewEnv project={project} disabled={!isAdmin} />
         </CardContent>
       </Card>

--- a/packages/web/app/_components/new-env-form.tsx
+++ b/packages/web/app/_components/new-env-form.tsx
@@ -1,0 +1,152 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { type z } from "zod";
+import { skipToken } from "@tanstack/react-query";
+import { type schema } from "@tableland/studio-store";
+import { envNameSchema } from "@tableland/studio-validators";
+import { FormRootMessage } from "@/components/form-root";
+import InputWithCheck from "@/components/input-with-check";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { api } from "@/trpc/react";
+
+export interface NewEnvFormProps {
+  projectId: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  trigger?: React.ReactNode;
+  onSuccess: (env: schema.Environment) => void;
+}
+
+export default function NewEnvForm({
+  projectId,
+  open,
+  onOpenChange,
+  trigger,
+  onSuccess,
+}: NewEnvFormProps) {
+  const [openSheet, setOpenSheet] = useState(open ?? false);
+  const [envName, setEnvName] = useState("");
+
+  const form = useForm<z.infer<typeof envNameSchema>>({
+    resolver: zodResolver(envNameSchema),
+    defaultValues: {
+      name: "",
+    },
+  });
+
+  useEffect(() => {
+    if (!openSheet) {
+      setEnvName("");
+      form.reset();
+    }
+    onOpenChange?.(openSheet);
+  }, [openSheet, onOpenChange, form]);
+
+  useEffect(() => {
+    setOpenSheet(open ?? false);
+  }, [open]);
+
+  const nameAvailableQuery = api.environments.nameAvailable.useQuery(
+    envName ? { projectId, name: envName } : skipToken,
+    { retry: false },
+  );
+
+  const newEnv = api.environments.newEnvironment.useMutation({
+    onSuccess: (env) => {
+      setOpenSheet(false);
+      onSuccess(env);
+    },
+    onError: (err) => {
+      setError("root", { message: err.message });
+    },
+  });
+
+  const { setError } = form;
+
+  function onSubmit(values: z.infer<typeof envNameSchema>) {
+    newEnv.mutate({ projectId, ...values });
+  }
+
+  return (
+    <Sheet open={openSheet} onOpenChange={setOpenSheet}>
+      {trigger && <SheetTrigger asChild>{trigger}</SheetTrigger>}
+      <SheetContent
+        className="overflow-scroll sm:max-w-xl"
+        closeDisabled={newEnv.isPending}
+        onPointerDownOutside={
+          newEnv.isPending ? (e) => e.preventDefault() : undefined
+        }
+        onEscapeKeyDown={
+          newEnv.isPending ? (e) => e.preventDefault() : undefined
+        }
+      >
+        <Form {...form}>
+          <form
+            // TODO: `form.handleSubmit` creates a floating promise, as a result the linter is complaining
+            //    we should figure out if this is ok or not and either change this or the lint config
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="mx-auto max-w-lg space-y-8"
+          >
+            <SheetHeader>
+              <SheetTitle>New Environment</SheetTitle>
+              {/* <SheetDescription>
+                This action cannot be undone. This will permanently delete your
+                account and remove your data from our servers.
+              </SheetDescription> */}
+            </SheetHeader>
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <InputWithCheck
+                      placeholder="Environment name"
+                      updateQuery={setEnvName}
+                      queryStatus={nameAvailableQuery}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Environment name must be unique within your project.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormRootMessage />
+            <Button
+              type="submit"
+              disabled={newEnv.isPending || !nameAvailableQuery.data}
+            >
+              {newEnv.isPending && (
+                <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+              )}
+              Submit
+            </Button>
+          </form>
+        </Form>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/packages/web/app/_components/primary-header-item.tsx
+++ b/packages/web/app/_components/primary-header-item.tsx
@@ -64,6 +64,9 @@ export default function PrimaryHeaderItem({
 
   const env = envsQuery.data?.find((env) => env.slug === envSlug);
 
+  const setEnvPreference =
+    api.environments.setEnvironmentPreferenceForProject.useMutation();
+
   function onTeamSelected(team: schema.Team) {
     router.push(`/${team.slug}`);
   }
@@ -94,7 +97,8 @@ export default function PrimaryHeaderItem({
 
   function onEnvironmentSelected(selectedEnv: schema.Environment) {
     navToEnv(selectedEnv);
-    // TODO: Set session record of this change.
+    if (!project) return;
+    setEnvPreference.mutate({ projectId: project.id, envId: selectedEnv.id });
   }
 
   function onNewEnvironmentSelected() {

--- a/packages/web/app/_components/primary-header-item.tsx
+++ b/packages/web/app/_components/primary-header-item.tsx
@@ -181,7 +181,7 @@ export default function PrimaryHeaderItem({
           selectedEnv={env}
           envs={envsQuery.data}
           onEnvSelected={onEnvironmentSelected}
-          onNewEnvSelected={onNewEnvironmentSelected}
+          onNewEnvSelected={foundTeam ? onNewEnvironmentSelected : undefined}
           key="environment-switcher"
         />,
         <NewEnvForm

--- a/packages/web/app/_components/primary-header-item.tsx
+++ b/packages/web/app/_components/primary-header-item.tsx
@@ -7,6 +7,7 @@ import { type schema } from "@tableland/studio-store";
 import { useState } from "react";
 import { skipToken } from "@tanstack/react-query";
 import Image from "next/image";
+import { Database, Folder, User, Users } from "lucide-react";
 import NewTeamForm from "./new-team-form";
 import NewEnvForm from "./new-env-form";
 import NewProjectForm from "@/components/new-project-form";
@@ -134,13 +135,20 @@ export default function PrimaryHeaderItem({
       <p className="text-lg text-slate-300" key="divider-1">
         /
       </p>,
-      <TeamSwitcher
-        selectedTeam={team}
-        teams={userTeams}
-        onTeamSelected={onTeamSelected}
-        onNewTeamSelected={onNewTeamSelected}
-        key="team-switcher"
-      />,
+      <div className="flex items-center gap-x-2">
+        {team.personal ? (
+          <User className="size-5" />
+        ) : (
+          <Users className="size-5" />
+        )}
+        <TeamSwitcher
+          selectedTeam={team}
+          teams={userTeams}
+          onTeamSelected={onTeamSelected}
+          onNewTeamSelected={onNewTeamSelected}
+          key="team-switcher"
+        />
+      </div>,
       <NewTeamForm
         onSuccess={onNewTeamSuccess}
         open={openNewTeamSheet}
@@ -153,14 +161,17 @@ export default function PrimaryHeaderItem({
         <p className="text-lg text-slate-300" key="divider-2">
           /
         </p>,
-        <ProjectSwitcher
-          team={team}
-          selectedProject={project}
-          projects={projects}
-          onProjectSelected={onProjectSelected}
-          onNewProjectSelected={foundTeam ? onNewProjectSelected : undefined}
-          key="project-switcher"
-        />,
+        <div className="flex items-center gap-x-2">
+          <Folder className="size-5" />
+          <ProjectSwitcher
+            team={team}
+            selectedProject={project}
+            projects={projects}
+            onProjectSelected={onProjectSelected}
+            onNewProjectSelected={foundTeam ? onNewProjectSelected : undefined}
+            key="project-switcher"
+          />
+        </div>,
         <NewProjectForm
           team={team}
           open={openNewProjectSheet}
@@ -175,15 +186,18 @@ export default function PrimaryHeaderItem({
         <p className="text-lg text-slate-300" key="divider-3">
           /
         </p>,
-        <EnvSwitcher
-          team={team}
-          project={project}
-          selectedEnv={env}
-          envs={envsQuery.data}
-          onEnvSelected={onEnvironmentSelected}
-          onNewEnvSelected={foundTeam ? onNewEnvironmentSelected : undefined}
-          key="environment-switcher"
-        />,
+        <div className="flex items-center gap-x-2">
+          <Database className="size-5" />
+          <EnvSwitcher
+            team={team}
+            project={project}
+            selectedEnv={env}
+            envs={envsQuery.data}
+            onEnvSelected={onEnvironmentSelected}
+            onNewEnvSelected={foundTeam ? onNewEnvironmentSelected : undefined}
+            key="environment-switcher"
+          />
+        </div>,
         <NewEnvForm
           projectId={project.id}
           open={openNewEnvSheet}
@@ -195,5 +209,5 @@ export default function PrimaryHeaderItem({
     }
   }
 
-  return <div className="flex flex-row items-center gap-x-3">{items}</div>;
+  return <div className="flex flex-row items-center gap-x-5">{items}</div>;
 }

--- a/packages/web/app/_components/primary-header-item.tsx
+++ b/packages/web/app/_components/primary-header-item.tsx
@@ -135,7 +135,7 @@ export default function PrimaryHeaderItem({
       <p className="text-lg text-slate-300" key="divider-1">
         /
       </p>,
-      <div className="flex items-center gap-x-2">
+      <div key="team-switcher" className="flex items-center gap-x-2">
         {team.personal ? (
           <User className="size-5" />
         ) : (
@@ -146,7 +146,6 @@ export default function PrimaryHeaderItem({
           teams={userTeams}
           onTeamSelected={onTeamSelected}
           onNewTeamSelected={onNewTeamSelected}
-          key="team-switcher"
         />
       </div>,
       <NewTeamForm
@@ -161,7 +160,7 @@ export default function PrimaryHeaderItem({
         <p className="text-lg text-slate-300" key="divider-2">
           /
         </p>,
-        <div className="flex items-center gap-x-2">
+        <div key="project-switcher" className="flex items-center gap-x-2">
           <Folder className="size-5" />
           <ProjectSwitcher
             team={team}
@@ -169,7 +168,6 @@ export default function PrimaryHeaderItem({
             projects={projects}
             onProjectSelected={onProjectSelected}
             onNewProjectSelected={foundTeam ? onNewProjectSelected : undefined}
-            key="project-switcher"
           />
         </div>,
         <NewProjectForm
@@ -186,7 +184,7 @@ export default function PrimaryHeaderItem({
         <p className="text-lg text-slate-300" key="divider-3">
           /
         </p>,
-        <div className="flex items-center gap-x-2">
+        <div key="environment-switcher" className="flex items-center gap-x-2">
           <Database className="size-5" />
           <EnvSwitcher
             team={team}
@@ -195,7 +193,6 @@ export default function PrimaryHeaderItem({
             envs={envsQuery.data}
             onEnvSelected={onEnvironmentSelected}
             onNewEnvSelected={foundTeam ? onNewEnvironmentSelected : undefined}
-            key="environment-switcher"
           />
         </div>,
         <NewEnvForm

--- a/packages/web/app/_components/primary-header-item.tsx
+++ b/packages/web/app/_components/primary-header-item.tsx
@@ -132,7 +132,7 @@ export default function PrimaryHeaderItem({
 
   if (team) {
     items.push(
-      <p className="text-lg text-slate-300" key="divider-1">
+      <p className="text-base text-muted-foreground" key="divider-1">
         /
       </p>,
       <div key="team-switcher" className="flex items-center gap-x-2">
@@ -157,7 +157,7 @@ export default function PrimaryHeaderItem({
     );
     if (project) {
       items.push(
-        <p className="text-lg text-slate-300" key="divider-2">
+        <p className="text-base text-muted-foreground" key="divider-2">
           /
         </p>,
         <div key="project-switcher" className="flex items-center gap-x-2">
@@ -181,7 +181,7 @@ export default function PrimaryHeaderItem({
     }
     if (project && env) {
       items.push(
-        <p className="text-lg text-slate-300" key="divider-3">
+        <p className="text-base text-muted-foreground" key="divider-3">
           /
         </p>,
         <div key="environment-switcher" className="flex items-center gap-x-2">

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -32,7 +32,7 @@
     --input: #635460;
     --ring: #6358dc;
 
-    --radius: 0.3rem;
+    --radius: 0.5rem;
   }
 
   .dark {

--- a/packages/web/components/edit-def.tsx
+++ b/packages/web/components/edit-def.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { type Schema, type schema } from "@tableland/studio-store";
 import { Loader2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { type z } from "zod";
 import { skipToken } from "@tanstack/react-query";
@@ -51,6 +51,10 @@ export default function EditDef({
       description: def.description,
     },
   });
+
+  useEffect(() => {
+    form.reset({ name: def.name, description: def.description });
+  }, [def, form]);
 
   const { handleSubmit, control, setError } = form;
 

--- a/packages/web/components/env-switcher.tsx
+++ b/packages/web/components/env-switcher.tsx
@@ -52,7 +52,7 @@ export default function EnvSwitcher({
       {variant === "navigation" && team && project && selectedEnv && (
         <Link
           href={`/${team.slug}/${project.slug}/${selectedEnv.slug}`}
-          className="underline-offset-2 hover:underline"
+          className="text-sm underline-offset-2 hover:underline"
         >
           {selectedEnv.name}
         </Link>

--- a/packages/web/components/env-switcher.tsx
+++ b/packages/web/components/env-switcher.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { type schema } from "@tableland/studio-store";
+import { Check, ChevronsUpDown, PlusCircle } from "lucide-react";
+import * as React from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import { Button } from "@/components/ui/button";
+
+type PopoverTriggerProps = React.ComponentPropsWithoutRef<
+  typeof PopoverTrigger
+>;
+
+interface EnvSwitcherProps extends PopoverTriggerProps {
+  variant?: "navigation" | "select";
+  team?: schema.Team;
+  project?: schema.Project;
+  selectedEnv?: schema.Environment;
+  envs?: schema.Environment[];
+  onEnvSelected?: (env: schema.Environment) => void;
+  onNewEnvSelected?: () => void;
+}
+
+export default function EnvSwitcher({
+  className,
+  variant = "navigation",
+  team,
+  project,
+  selectedEnv,
+  envs,
+  onEnvSelected,
+  onNewEnvSelected,
+  disabled,
+}: EnvSwitcherProps) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <div className="flex items-center gap-1">
+      {variant === "navigation" && team && project && selectedEnv && (
+        <Link
+          href={`/${team.slug}/${project.slug}/${selectedEnv.slug}`}
+          className="underline-offset-2 hover:underline"
+        >
+          {selectedEnv.name}
+        </Link>
+      )}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild disabled={disabled}>
+          <Button
+            variant={variant === "navigation" ? "ghost" : "outline"}
+            size={variant === "navigation" ? "sm" : "default"}
+            role="combobox"
+            aria-expanded={open}
+            aria-label="Select an environment"
+            className={cn(
+              "justify-between",
+              variant === "navigation" && "px-0",
+              className,
+            )}
+          >
+            {variant === "select" &&
+              (selectedEnv?.name ?? "Select an environment...")}
+            <ChevronsUpDown className="m-1 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[200px] p-0">
+          <Command>
+            <CommandList>
+              <CommandEmpty>No environments found.</CommandEmpty>
+              <CommandGroup heading="Environments">
+                {!envs?.length && (
+                  <p className="text-center text-sm">No environments found</p>
+                )}
+                {envs?.map((env) => (
+                  <CommandItem
+                    key={env.id}
+                    onSelect={() => {
+                      onEnvSelected?.(env);
+                      setOpen(false);
+                    }}
+                    className="text-sm"
+                  >
+                    {env.name}
+                    <Check
+                      className={cn(
+                        "ml-auto h-4 w-4",
+                        env.id === selectedEnv?.id
+                          ? "opacity-100"
+                          : "opacity-0",
+                      )}
+                    />
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+            {onNewEnvSelected && (
+              <>
+                <CommandSeparator />
+                <CommandList>
+                  <CommandGroup>
+                    <CommandItem onSelect={onNewEnvSelected}>
+                      <PlusCircle className="mr-2 h-5 w-5" />
+                      New Environment
+                    </CommandItem>
+                  </CommandGroup>
+                </CommandList>
+              </>
+            )}
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/packages/web/components/import-table-form.tsx
+++ b/packages/web/components/import-table-form.tsx
@@ -88,12 +88,23 @@ export default function ImportTableForm({
       chainId: chainIdPreset ?? 0,
       tableId: tableIdPreset ?? "",
       defName: "",
-      defDescription: undefined,
+      defDescription: "",
       environmentId: envPreset?.id ?? "",
     },
   });
 
-  const { handleSubmit, control, register, setValue, setError, watch } = form;
+  const { handleSubmit, control, register, setValue, setError, watch, reset } =
+    form;
+
+  useEffect(() => {
+    reset({
+      chainId: chainIdPreset ?? 0,
+      tableId: tableIdPreset ?? "",
+      defName: "",
+      defDescription: "",
+      environmentId: envPreset?.id ?? "",
+    });
+  }, [chainIdPreset, tableIdPreset, envPreset, reset]);
 
   const chainId = watch("chainId");
   const tableId = watch("tableId");

--- a/packages/web/components/import-table-form.tsx
+++ b/packages/web/components/import-table-form.tsx
@@ -16,6 +16,7 @@ import {
 } from "./ui/sheet";
 import TeamSwitcher from "./team-switcher";
 import ProjectSwitcher from "./project-switcher";
+import EnvSwitcher from "./env-switcher";
 import ChainSelector from "@/components/chain-selector";
 import { FormRootMessage } from "@/components/form-root";
 import InputWithCheck from "@/components/input-with-check";
@@ -38,7 +39,6 @@ export interface ImportTableFormProps {
   teamPreset?: schema.Team;
   projectPreset?: schema.Project;
   envPreset?: schema.Environment;
-  showSelectors?: boolean;
   chainIdPreset?: number;
   tableIdPreset?: string;
   open?: boolean;
@@ -57,7 +57,6 @@ export default function ImportTableForm({
   teamPreset,
   projectPreset,
   envPreset,
-  showSelectors,
   chainIdPreset,
   tableIdPreset,
   open,
@@ -103,22 +102,15 @@ export default function ImportTableForm({
     if (!openSheet) {
       setTeam(teamPreset);
       setProject(projectPreset);
+      setEnv(envPreset);
       form.reset();
     }
     onOpenChange?.(openSheet);
-  }, [openSheet, teamPreset, projectPreset, onOpenChange, form]);
+  }, [openSheet, teamPreset, projectPreset, envPreset, onOpenChange, form]);
 
   useEffect(() => {
     setOpenSheet(open ?? false);
   }, [open]);
-
-  // TODO: Display UI to choose environment.
-  useEffect(() => {
-    const env = envs?.[0];
-    if (!env) return;
-    setValue("environmentId", env.id);
-    setEnv(env);
-  }, [envs, setValue]);
 
   useEffect(() => {
     if (!(!!chainId && !!tableId)) {
@@ -204,29 +196,43 @@ export default function ImportTableForm({
                 account and remove your data from our servers.
               </SheetDescription> */}
             </SheetHeader>
-            {(showSelectors ?? !teamPreset ?? !projectPreset) && (
-              <>
-                <div className="space-y-2">
-                  <FormLabel>Team</FormLabel>
-                  <TeamSwitcher
-                    variant="select"
-                    teams={teams}
-                    selectedTeam={team}
-                    onTeamSelected={handleTeamSelected}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <FormLabel>Project</FormLabel>
-                  <ProjectSwitcher
-                    variant="select"
-                    team={team}
-                    projects={projects}
-                    selectedProject={project}
-                    onProjectSelected={setProject}
-                    disabled={!team}
-                  />
-                </div>
-              </>
+            {!teamPreset && (
+              <div className="space-y-2">
+                <FormLabel>Team</FormLabel>
+                <TeamSwitcher
+                  variant="select"
+                  teams={teams}
+                  selectedTeam={team}
+                  onTeamSelected={handleTeamSelected}
+                />
+              </div>
+            )}
+            {!projectPreset && (
+              <div className="space-y-2">
+                <FormLabel>Project</FormLabel>
+                <ProjectSwitcher
+                  variant="select"
+                  team={team}
+                  projects={projects}
+                  selectedProject={project}
+                  onProjectSelected={setProject}
+                  disabled={!team}
+                />
+              </div>
+            )}
+            {!envPreset && (
+              <div className="space-y-2">
+                <FormLabel>Environment</FormLabel>
+                <EnvSwitcher
+                  variant="select"
+                  team={team}
+                  project={project}
+                  envs={envs}
+                  selectedEnv={env}
+                  onEnvSelected={setEnv}
+                  disabled={!project}
+                />
+              </div>
             )}
             <FormField
               control={control}

--- a/packages/web/components/import-table-form.tsx
+++ b/packages/web/components/import-table-form.tsx
@@ -112,6 +112,7 @@ export default function ImportTableForm({
     setOpenSheet(open ?? false);
   }, [open]);
 
+  // TODO: Display UI to choose environment.
   useEffect(() => {
     const env = envs?.[0];
     if (!env) return;

--- a/packages/web/components/new-def-form.tsx
+++ b/packages/web/components/new-def-form.tsx
@@ -97,6 +97,25 @@ export default function NewDefForm({
   });
 
   useEffect(() => {
+    form.reset({
+      name: "",
+      description: "",
+      columns: schemaPreset
+        ? [
+            {
+              id: "dummy",
+              name: "dummy",
+              type: "int",
+              notNull: false,
+              primaryKey: false,
+              unique: false,
+            },
+          ]
+        : [],
+    });
+  }, [schemaPreset, form]);
+
+  useEffect(() => {
     if (!openSheet) {
       setTeam(teamPreset);
       setProject(projectPreset);

--- a/packages/web/components/new-def-form.tsx
+++ b/packages/web/components/new-def-form.tsx
@@ -42,7 +42,6 @@ import DefColumns from "@/components/def-columns";
 export interface NewDefFormProps {
   teamPreset?: schema.Team;
   projectPreset?: schema.Project;
-  showSelectors?: boolean;
   schemaPreset?: Schema;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -57,7 +56,6 @@ export interface NewDefFormProps {
 export default function NewDefForm({
   teamPreset,
   projectPreset,
-  showSelectors,
   schemaPreset,
   open,
   onOpenChange,
@@ -197,29 +195,29 @@ export default function NewDefForm({
                 account and remove your data from our servers.
               </SheetDescription> */}
             </SheetHeader>
-            {(showSelectors ?? !teamPreset ?? !projectPreset) && (
-              <>
-                <div className="space-y-2">
-                  <FormLabel>Team</FormLabel>
-                  <TeamSwitcher
-                    variant="select"
-                    teams={teams}
-                    selectedTeam={team}
-                    onTeamSelected={handleTeamSelected}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <FormLabel>Project</FormLabel>
-                  <ProjectSwitcher
-                    variant="select"
-                    team={team}
-                    projects={projects}
-                    selectedProject={project}
-                    onProjectSelected={setProject}
-                    disabled={!team}
-                  />
-                </div>
-              </>
+            {!teamPreset && (
+              <div className="space-y-2">
+                <FormLabel>Team</FormLabel>
+                <TeamSwitcher
+                  variant="select"
+                  teams={teams}
+                  selectedTeam={team}
+                  onTeamSelected={handleTeamSelected}
+                />
+              </div>
+            )}
+            {!projectPreset && (
+              <div className="space-y-2">
+                <FormLabel>Project</FormLabel>
+                <ProjectSwitcher
+                  variant="select"
+                  team={team}
+                  projects={projects}
+                  selectedProject={project}
+                  onProjectSelected={setProject}
+                  disabled={!team}
+                />
+              </div>
             )}
             <FormField
               control={control}

--- a/packages/web/components/new-project-form.tsx
+++ b/packages/web/components/new-project-form.tsx
@@ -28,6 +28,7 @@ import {
 import { Button } from "@/components/ui/button";
 import InputWithCheck from "@/components/input-with-check";
 import { FormRootMessage } from "@/components/form-root";
+import { cn } from "@/lib/utils";
 
 export interface NewProjectFormProps {
   team: schema.Team;
@@ -71,7 +72,9 @@ export default function NewProjectForm({
     },
   });
 
-  const { setError, control, register } = form;
+  const { setError, control, register, watch } = form;
+
+  const envsCount = watch("envNames").length;
 
   const {
     fields: envNamesFields,
@@ -124,7 +127,6 @@ export default function NewProjectForm({
           >
             <SheetHeader>
               <SheetTitle>New Project</SheetTitle>
-              <pre>{JSON.stringify(envNamesFields, null, 2)}</pre>
               {/* <SheetDescription>
                 This action cannot be undone. This will permanently delete your
                 account and remove your data from our servers.
@@ -169,67 +171,61 @@ export default function NewProjectForm({
                 </FormItem>
               )}
             />
-            <FormField
-              control={control}
-              name="envNames"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Environments</FormLabel>
-                  <FormControl>
-                    <div className="space-y-3" {...field}>
-                      {envNamesFields.map((envName, index) => (
-                        <FormField
-                          key={envName.id}
-                          control={control}
-                          name={`envNames.${index}.name`}
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormControl>
-                                <div className="flex items-center gap-2">
-                                  <Input
-                                    placeholder="Environment name"
-                                    {...register(`envNames.${index}.name`)}
-                                    {...field}
-                                  />
-                                  <Button
-                                    type="button"
-                                    variant="ghost"
-                                    size="icon"
-                                    onClick={() => removeEnvName(index)}
-                                  >
-                                    <X />
-                                  </Button>
-                                </div>
-                              </FormControl>
-                              <FormMessage />
-                            </FormItem>
+            <div>
+              {envNamesFields.map((envName, index) => (
+                <FormField
+                  key={envName.id}
+                  control={control}
+                  name={`envNames.${index}.name`}
+                  render={({ field, formState }) => (
+                    <FormItem>
+                      <FormLabel className={cn(index !== 0 && "sr-only")}>
+                        Environments
+                      </FormLabel>
+                      <FormDescription className={cn(index !== 0 && "sr-only")}>
+                        Environments are logical groups of tables. You could,
+                        for example, use them to create &quot;staging&quot; and
+                        &quot;production&quot; groups of tables. All of your
+                        project&apos;s table definitions are available in each
+                        environment, but you can deploy those table definitions
+                        to Tableland separately per environment. Your project
+                        must have at least one environment.
+                      </FormDescription>
+                      <FormControl>
+                        <div className="flex items-center gap-2">
+                          <Input
+                            placeholder="Environment name"
+                            {...register(`envNames.${index}.name`)}
+                            {...field}
+                          />
+                          {envsCount > 1 && (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => removeEnvName(index)}
+                            >
+                              <X />
+                            </Button>
                           )}
-                        />
-                      ))}
-                      <Button
-                        type="button"
-                        variant="secondary"
-                        size="sm"
-                        onClick={() => appendEnvName({ name: "" })}
-                      >
-                        <Plus className="mr-2 size-5" />
-                        Add Environment
-                      </Button>
-                    </div>
-                  </FormControl>
-                  <FormDescription>
-                    Specify at least one environment for your Project.
-                    Environments are logical groups of tables. You could, for
-                    example, use them to create &quot;staging&quot; and
-                    &quot;production&quot; groups of tables. All of your
-                    project&apos;s table definitions are available in each
-                    environment, but you can deploy those table definitions to
-                    Tableland separately per environment.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              ))}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-2"
+                onClick={() => appendEnvName({ name: "" })}
+              >
+                <Plus className="mr-2 size-5" />
+                Add Environment
+              </Button>
+            </div>
             <FormRootMessage />
             <Button
               type="submit"

--- a/packages/web/components/new-project-form.tsx
+++ b/packages/web/components/new-project-form.tsx
@@ -183,13 +183,13 @@ export default function NewProjectForm({
                         Environments
                       </FormLabel>
                       <FormDescription className={cn(index !== 0 && "sr-only")}>
-                        Environments are logical groups of tables. You could,
-                        for example, use them to create &quot;staging&quot; and
-                        &quot;production&quot; groups of tables. All of your
-                        project&apos;s table definitions are available in each
-                        environment, but you can deploy those table definitions
-                        to Tableland separately per environment. Your project
-                        must have at least one environment.
+                        Environments are logical groups of definitions. You
+                        could, for example, use them to create
+                        &quot;staging&quot; and &quot;production&quot; groups of
+                        definitions. All of your project&apos;s definitions are
+                        available in each environment, but you can deploy those
+                        definitions to Tableland separately per environment.
+                        Your project must have at least one environment.
                       </FormDescription>
                       <FormControl>
                         <div className="flex items-center gap-2">

--- a/packages/web/components/project-switcher.tsx
+++ b/packages/web/components/project-switcher.tsx
@@ -50,7 +50,7 @@ export default function ProjectSwitcher({
       {variant === "navigation" && team && selectedProject && (
         <Link
           href={`/${team.slug}/${selectedProject.slug}`}
-          className="underline-offset-2 hover:underline"
+          className="text-sm underline-offset-2 hover:underline"
         >
           {selectedProject.name}
         </Link>

--- a/packages/web/components/projects-referencing-table.tsx
+++ b/packages/web/components/projects-referencing-table.tsx
@@ -19,7 +19,7 @@ export default function ProjectsReferencingTable({
         {references.map((p) => (
           <li key={p.project.id}>
             <Link
-              href={`/${p.team.slug}/${p.project.slug}/tables/${p.environment.slug}/${p.def.slug}`}
+              href={`/${p.team.slug}/${p.project.slug}/${p.environment.slug}/${p.def.slug}`}
               className="text-foreground"
             >
               {p.team.name}/{p.project.name}

--- a/packages/web/components/sidebar-link.tsx
+++ b/packages/web/components/sidebar-link.tsx
@@ -16,15 +16,15 @@ export default function SidebarLink({
   showIndicator?: boolean;
 }) {
   return (
-    <Link href={href}>
+    <Link href={href} title={title}>
       <Button
         variant={selected ? "secondary" : "ghost"}
-        className="h-auto w-full justify-start gap-x-2 px-3 py-2"
+        className="flex h-auto w-full justify-start gap-x-2 px-3 py-2 font-normal"
       >
-        <Icon className="size-5" />
-        {title}
+        <Icon className="size-5 shrink-0" />
+        <div className="shrink truncate">{title}</div>
         {showIndicator && (
-          <div className="ml-auto size-2 rounded-full bg-primary" />
+          <div className="ml-auto size-2 shrink-0 rounded-full bg-primary" />
         )}
       </Button>
     </Link>

--- a/packages/web/components/sidebar-link.tsx
+++ b/packages/web/components/sidebar-link.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { type LucideIcon } from "lucide-react";
+import { Button } from "./ui/button";
+
+export default function SidebarLink({
+  title,
+  Icon,
+  href,
+  selected,
+  showIndicator = false,
+}: {
+  title: string;
+  Icon: LucideIcon;
+  href: string;
+  selected: boolean;
+  showIndicator?: boolean;
+}) {
+  return (
+    <Link href={href}>
+      <Button
+        variant={selected ? "secondary" : "ghost"}
+        className="w-full justify-start gap-x-2 px-3"
+      >
+        <Icon className="size-5" />
+        {title}
+        {showIndicator && (
+          <div className="ml-auto size-2 rounded-full bg-primary" />
+        )}
+      </Button>
+    </Link>
+  );
+}

--- a/packages/web/components/sidebar-link.tsx
+++ b/packages/web/components/sidebar-link.tsx
@@ -4,13 +4,13 @@ import { Button } from "./ui/button";
 
 export default function SidebarLink({
   title,
-  Icon,
+  icon: Icon,
   href,
   selected,
   showIndicator = false,
 }: {
   title: string;
-  Icon: LucideIcon;
+  icon: LucideIcon;
   href: string;
   selected: boolean;
   showIndicator?: boolean;

--- a/packages/web/components/sidebar-link.tsx
+++ b/packages/web/components/sidebar-link.tsx
@@ -19,7 +19,7 @@ export default function SidebarLink({
     <Link href={href}>
       <Button
         variant={selected ? "secondary" : "ghost"}
-        className="w-full justify-start gap-x-2 px-3"
+        className="h-auto w-full justify-start gap-x-2 px-3 py-2"
       >
         <Icon className="size-5" />
         {title}

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -7,7 +7,7 @@ export function SidebarContainer({
   ...props
 }: HTMLAttributes<HTMLDivElement>) {
   return (
-    <div className={cn("space-y-8 p-3", className)} {...props}>
+    <div className={cn("space-y-8", className)} {...props}>
       {children}
     </div>
   );

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -7,7 +7,7 @@ export function SidebarContainer({
   ...props
 }: HTMLAttributes<HTMLDivElement>) {
   return (
-    <div className={cn("space-y-8", className)} {...props}>
+    <div className={cn(className)} {...props}>
       {children}
     </div>
   );
@@ -19,7 +19,7 @@ export function SidebarSection({
   ...props
 }: HTMLAttributes<HTMLDivElement>) {
   return (
-    <div className={cn("flex flex-col space-y-3", className)} {...props}>
+    <div className={cn("flex flex-col gap-3 p-3", className)} {...props}>
       {children}
     </div>
   );

--- a/packages/web/components/table-menu.tsx
+++ b/packages/web/components/table-menu.tsx
@@ -187,26 +187,26 @@ export default function TableMenu({
         <DropdownMenuContent>
           {displaySettings && (
             <DropdownMenuItem onSelect={() => setTableSettingsOpen(true)}>
-              Table settings
+              Settings
             </DropdownMenuItem>
           )}
           {displayDeploy && (
             <DropdownMenuItem onSelect={() => setExecDeploymentOpen(true)}>
-              Deploy table definition to Tableland
+              Deploy to Tableland
             </DropdownMenuItem>
           )}
           {displayImportToStudio && (
             <DropdownMenuItem onSelect={() => setImportTableFormOpen(true)}>
-              Import table into Studio project
+              Import table as definition
             </DropdownMenuItem>
           )}
           {displayImportFromTableland && (
             <DropdownMenuItem onSelect={() => setImportTableFormOpen(true)}>
-              Import table from Tableland
+              Attach existing table to definition
             </DropdownMenuItem>
           )}
           <DropdownMenuItem onSelect={() => setNewDefFormOpen(true)}>
-            Use table definition in Studio project
+            Use schema in new definition
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/packages/web/components/table-menu.tsx
+++ b/packages/web/components/table-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { EllipsisVertical } from "lucide-react";
+import { Ellipsis } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { type Schema, type schema } from "@tableland/studio-store";
@@ -172,7 +172,7 @@ export default function TableMenu({
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="icon">
-            <EllipsisVertical />
+            <Ellipsis />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>

--- a/packages/web/components/table-menu.tsx
+++ b/packages/web/components/table-menu.tsx
@@ -85,6 +85,7 @@ export default function TableMenu({
     setDeleteTableOpen(false);
     void defsQuery.refetch();
     if (!team || !project || !env) return;
+    router.refresh();
     router.replace(`/${team.slug}/${project.slug}/${env.slug}`);
   };
 

--- a/packages/web/components/table-menu.tsx
+++ b/packages/web/components/table-menu.tsx
@@ -197,12 +197,12 @@ export default function TableMenu({
           )}
           {displayImportToStudio && (
             <DropdownMenuItem onSelect={() => setImportTableFormOpen(true)}>
-              Import table as definition
+              Import table to project definition
             </DropdownMenuItem>
           )}
           {displayImportFromTableland && (
             <DropdownMenuItem onSelect={() => setImportTableFormOpen(true)}>
-              Attach existing table to definition
+              Attach existing table to this definition
             </DropdownMenuItem>
           )}
           <DropdownMenuItem onSelect={() => setNewDefFormOpen(true)}>

--- a/packages/web/components/table-menu.tsx
+++ b/packages/web/components/table-menu.tsx
@@ -8,7 +8,9 @@ import { skipToken } from "@tanstack/react-query";
 import { type RouterOutputs } from "@tableland/studio-api";
 import { Button } from "./ui/button";
 import NewDefForm from "./new-def-form";
-import ImportTableForm from "./import-table-form";
+import ImportTableForm, {
+  type ImportTableFormProps,
+} from "./import-table-form";
 import TableSettings from "./table-settings";
 import { DeleteTableDialog } from "./delete-table-dialog";
 import { UndeployTableDialog } from "./undeploy-table-dialog";
@@ -46,7 +48,9 @@ export default function TableMenu({
   const [tableSettingsOpen, setTableSettingsOpen] = useState(false);
   const [execDeploymentOpen, setExecDeploymentOpen] = useState(false);
   const [newDefFormOpen, setNewDefFormOpen] = useState(false);
-  const [importTableFormOpen, setImportTableFormOpen] = useState(false);
+  const [importTableFormProps, setImportTableFormProps] = useState<
+    Partial<ImportTableFormProps> | undefined
+  >(undefined);
   const [deleteTableOpen, setDeleteTableOpen] = useState(false);
   const [undeployTableOpen, setUndeployTableOpen] = useState(false);
   const router = useRouter();
@@ -146,14 +150,9 @@ export default function TableMenu({
         />
       )}
       <ImportTableForm
-        teamPreset={team}
-        projectPreset={project}
-        envPreset={env}
-        chainIdPreset={chainId}
-        tableIdPreset={tableId}
-        defId={def?.id}
-        open={importTableFormOpen}
-        onOpenChange={setImportTableFormOpen}
+        {...importTableFormProps}
+        open={!!importTableFormProps}
+        onOpenChange={(open) => !open && setImportTableFormProps(undefined)}
         onSuccess={(team, project, def, env) => {
           router.refresh();
           const newPathname = `/${team.slug}/${project.slug}/${env.slug}/${def.slug}`;
@@ -196,12 +195,29 @@ export default function TableMenu({
             </DropdownMenuItem>
           )}
           {displayImportToStudio && (
-            <DropdownMenuItem onSelect={() => setImportTableFormOpen(true)}>
-              Import table to project definition
+            <DropdownMenuItem
+              onSelect={() =>
+                setImportTableFormProps({
+                  chainIdPreset: chainId,
+                  tableIdPreset: tableId,
+                  descriptionPreset: def?.description,
+                })
+              }
+            >
+              Import table as definition
             </DropdownMenuItem>
           )}
           {displayImportFromTableland && (
-            <DropdownMenuItem onSelect={() => setImportTableFormOpen(true)}>
+            <DropdownMenuItem
+              onSelect={() =>
+                setImportTableFormProps({
+                  teamPreset: team,
+                  projectPreset: project,
+                  envPreset: env,
+                  defId: def?.id,
+                })
+              }
+            >
               Attach existing table to this definition
             </DropdownMenuItem>
           )}

--- a/packages/web/components/table-wrapper.tsx
+++ b/packages/web/components/table-wrapper.tsx
@@ -20,7 +20,7 @@ export default async function TableWrapper({
 }) {
   return (
     <div className="flex-1 space-y-4">
-      <div className="space-y-2">
+      <div>
         <div className="flex items-center gap-4">
           <h1 className="text-3xl font-medium">{displayName}</h1>
           {isAuthenticated && <TableMenu {...props} />}

--- a/packages/web/components/table.tsx
+++ b/packages/web/components/table.tsx
@@ -140,7 +140,7 @@ export default async function Table({
             tooltipText="Click to copy table name"
           >
             <Table2 className="h-4 w-4 text-muted-foreground" />
-            <MetricCardTitle>Tableland Table</MetricCardTitle>
+            <MetricCardTitle>Table</MetricCardTitle>
           </MetricCardHeader>
           <MetricCardContent tooltipText={tableName}>
             {tableName}
@@ -217,9 +217,7 @@ export default async function Table({
           <MetricCard>
             <MetricCardHeader className="flex flex-row items-center gap-2 space-y-0">
               <Workflow className="h-4 w-4 text-muted-foreground" />
-              <MetricCardTitle>
-                Studio projects using this table
-              </MetricCardTitle>
+              <MetricCardTitle>Referenced by projects</MetricCardTitle>
             </MetricCardHeader>
             <CardContent>
               <ProjectsReferencingTable
@@ -236,7 +234,7 @@ export default async function Table({
             <>
               <TabsTrigger value="data">Table Data</TabsTrigger>
               <TabsTrigger value="logs">SQL Logs</TabsTrigger>
-              <TabsTrigger value="definition">Definition</TabsTrigger>
+              <TabsTrigger value="definition">Schema</TabsTrigger>
             </>
           ) : (
             <h2 className="text-base font-medium text-foreground">

--- a/packages/web/components/table.tsx
+++ b/packages/web/components/table.tsx
@@ -29,7 +29,7 @@ import { Alert, AlertDescription, AlertTitle } from "./ui/alert";
 import { blockExplorers } from "@/lib/block-explorers";
 import { openSeaLinks } from "@/lib/open-sea";
 import { chainsMap } from "@/lib/chains-map";
-import { objectToTableData } from "@/lib/utils";
+import { cn, objectToTableData } from "@/lib/utils";
 import { TimeSince } from "@/components/time";
 import { api } from "@/trpc/server";
 import DefDetails from "@/components/def-details";
@@ -231,12 +231,23 @@ export default async function Table({
         )}
       </div>
       <Tabs defaultValue={data ? "data" : "definition"} className="py-4">
-        <TabsList>
+        <TabsList
+          className={cn(
+            !data || (!(formattedData && columns) && "bg-transparent"),
+          )}
+        >
           {formattedData && columns && (
             <TabsTrigger value="data">Table Data</TabsTrigger>
           )}
           {data && <TabsTrigger value="logs">SQL Logs</TabsTrigger>}
-          <TabsTrigger value="definition">Definition</TabsTrigger>
+          <TabsTrigger
+            value="definition"
+            className={cn(
+              !data || (!(formattedData && columns) && "bg-transparent"),
+            )}
+          >
+            Definition
+          </TabsTrigger>
         </TabsList>
         {formattedData && columns && (
           <TabsContent value="data">

--- a/packages/web/components/table.tsx
+++ b/packages/web/components/table.tsx
@@ -231,23 +231,18 @@ export default async function Table({
         )}
       </div>
       <Tabs defaultValue={data ? "data" : "definition"} className="py-4">
-        <TabsList
-          className={cn(
-            !data || (!(formattedData && columns) && "bg-transparent"),
+        <TabsList className={cn(!data && "bg-transparent")}>
+          {data && formattedData && columns ? (
+            <>
+              <TabsTrigger value="data">Table Data</TabsTrigger>
+              <TabsTrigger value="logs">SQL Logs</TabsTrigger>
+              <TabsTrigger value="definition">Definition</TabsTrigger>
+            </>
+          ) : (
+            <h2 className="text-base font-medium text-foreground">
+              Definition
+            </h2>
           )}
-        >
-          {formattedData && columns && (
-            <TabsTrigger value="data">Table Data</TabsTrigger>
-          )}
-          {data && <TabsTrigger value="logs">SQL Logs</TabsTrigger>}
-          <TabsTrigger
-            value="definition"
-            className={cn(
-              !data || (!(formattedData && columns) && "bg-transparent"),
-            )}
-          >
-            Definition
-          </TabsTrigger>
         </TabsList>
         {formattedData && columns && (
           <TabsContent value="data">

--- a/packages/web/components/team-switcher.tsx
+++ b/packages/web/components/team-switcher.tsx
@@ -66,7 +66,7 @@ export default function TeamSwitcher({
       {variant === "navigation" && selectedTeam && (
         <Link
           href={`/${selectedTeam.slug}`}
-          className="underline-offset-2 hover:underline"
+          className="text-sm underline-offset-2 hover:underline"
         >
           {selectedTeam.name}
         </Link>


### PR DESCRIPTION
Main thing here is exposing envs in the UI, but that also led to some new features and styling improvements.

- Expose envs
- Allow users to specify envs when creating a new project
- Allow users to edit envs in project settings
- Allow users to create a new env from the envs switcher
- Allow user to choose team/project/env when importing a table
- Allow user to import a table to an already existing def for the currently selected env
- Whenever the user selects a different env within a project, save that preference in their session
- Whenever the user is navigating to a project and there is no implied env within the context that they are working (when navigating from the Studio landing page or a team page list of projects, etc), read the env to navigate to from the preferences stored in their session.
- New team page listing projects
- Probably more