### PR TITLE
Fix layout

### DIFF
--- a/packages/web/app/[team]/(team)/layout.tsx
+++ b/packages/web/app/[team]/(team)/layout.tsx
@@ -6,11 +6,11 @@ export default async function LayoutTeam({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex flex-1 items-stretch">
+    <div className="flex flex-1">
       <div className="sticky top-[3.55rem] h-[calc(100vh-3.55rem)] w-52 flex-shrink-0 overflow-y-auto overflow-x-hidden border-r border-[#080A1E] bg-card">
         <Sidebar />
       </div>
-      <div className="flex w-full">{children}</div>
+      <div className="mx-auto w-full min-w-0">{children}</div>
     </div>
   );
 }

--- a/packages/web/app/[team]/(team)/page.tsx
+++ b/packages/web/app/[team]/(team)/page.tsx
@@ -34,7 +34,7 @@ export default async function Projects({
   );
 
   return (
-    <main className="container flex max-w-5xl flex-1 flex-col items-stretch gap-4 p-4">
+    <main className="container flex max-w-5xl flex-col items-stretch gap-4 p-4">
       <div className="flex items-end">
         <h1 className="text-3xl font-medium">{team.name} projects</h1>
         {authorized && <NewProjectButton team={team} className="ml-auto" />}

--- a/packages/web/app/[team]/[project]/[env]/[table]/page.tsx
+++ b/packages/web/app/[team]/[project]/[env]/[table]/page.tsx
@@ -40,7 +40,7 @@ export default async function Deployments({
   const isAuthorized = await cache(api.teams.isAuthorized)({ teamId: team.id });
 
   return (
-    <main className="flex-1 p-4">
+    <main className="p-4">
       <TableWrapper
         team={team}
         project={project}

--- a/packages/web/app/[team]/[project]/layout.tsx
+++ b/packages/web/app/[team]/[project]/layout.tsx
@@ -6,11 +6,11 @@ export default async function ProjectLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex flex-1 items-stretch">
+    <div className="flex flex-1">
       <div className="sticky top-[3.55rem] h-[calc(100vh-3.55rem)] w-52 flex-shrink-0 overflow-y-auto overflow-x-hidden border-r border-[#080A1E] bg-card">
         <Sidebar />
       </div>
-      <div className="w-full">{children}</div>
+      <div className="mx-auto w-full min-w-0">{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
In the case of viewing a project's table that has been deployed and the displayed data table is wider than the screen, the whole page was getting a horizonal scroll bar. The desired behaviour is the page content is never wider than the screen, and the data table component itseld scrolls horizontally. This change does that.