### PR TITLE
Better styling for switcher components

### DIFF
--- a/packages/web/app/_components/primary-header-item.tsx
+++ b/packages/web/app/_components/primary-header-item.tsx
@@ -151,6 +151,7 @@ export default function PrimaryHeaderItem({
           teams={userTeams}
           onTeamSelected={onTeamSelected}
           onNewTeamSelected={onNewTeamSelected}
+          className="font-medium"
         />
       </div>,
       <NewTeamForm
@@ -173,6 +174,7 @@ export default function PrimaryHeaderItem({
             projects={projects}
             onProjectSelected={onProjectSelected}
             onNewProjectSelected={foundTeam ? onNewProjectSelected : undefined}
+            className="font-medium"
           />
         </div>,
         <NewProjectForm
@@ -198,6 +200,7 @@ export default function PrimaryHeaderItem({
             envs={envsQuery.data}
             onEnvSelected={onEnvironmentSelected}
             onNewEnvSelected={foundTeam ? onNewEnvironmentSelected : undefined}
+            className="font-medium"
           />
         </div>,
         <NewEnvForm

--- a/packages/web/components/env-switcher.tsx
+++ b/packages/web/components/env-switcher.tsx
@@ -20,11 +20,7 @@ import {
 } from "@/components/ui/command";
 import { Button } from "@/components/ui/button";
 
-type PopoverTriggerProps = React.ComponentPropsWithoutRef<
-  typeof PopoverTrigger
->;
-
-interface EnvSwitcherProps extends PopoverTriggerProps {
+type EnvSwitcherProps = {
   variant?: "navigation" | "select";
   team?: schema.Team;
   project?: schema.Project;
@@ -32,7 +28,8 @@ interface EnvSwitcherProps extends PopoverTriggerProps {
   envs?: schema.Environment[];
   onEnvSelected?: (env: schema.Environment) => void;
   onNewEnvSelected?: () => void;
-}
+  disabled?: boolean;
+} & React.HTMLAttributes<HTMLDivElement>;
 
 export default function EnvSwitcher({
   className,
@@ -44,11 +41,12 @@ export default function EnvSwitcher({
   onEnvSelected,
   onNewEnvSelected,
   disabled,
+  ...rest
 }: EnvSwitcherProps) {
   const [open, setOpen] = React.useState(false);
 
   return (
-    <div className="flex items-center gap-1">
+    <div className={cn("flex items-center gap-1", className)} {...rest}>
       {variant === "navigation" && team && project && selectedEnv && (
         <Link
           href={`/${team.slug}/${project.slug}/${selectedEnv.slug}`}
@@ -68,7 +66,6 @@ export default function EnvSwitcher({
             className={cn(
               "justify-between",
               variant === "navigation" && "px-0",
-              className,
             )}
           >
             {variant === "select" &&

--- a/packages/web/components/project-switcher.tsx
+++ b/packages/web/components/project-switcher.tsx
@@ -20,18 +20,15 @@ import {
 } from "@/components/ui/command";
 import { Button } from "@/components/ui/button";
 
-type PopoverTriggerProps = React.ComponentPropsWithoutRef<
-  typeof PopoverTrigger
->;
-
-interface ProjectSwitcherProps extends PopoverTriggerProps {
+type ProjectSwitcherProps = {
   variant?: "navigation" | "select";
   team?: schema.Team;
   selectedProject?: schema.Project;
   projects?: schema.Project[];
   onProjectSelected?: (project: schema.Project) => void;
   onNewProjectSelected?: () => void;
-}
+  disabled?: boolean;
+} & React.HTMLAttributes<HTMLDivElement>;
 
 export default function ProjectSwitcher({
   className,
@@ -42,11 +39,12 @@ export default function ProjectSwitcher({
   onProjectSelected,
   onNewProjectSelected,
   disabled,
+  ...rest
 }: ProjectSwitcherProps) {
   const [open, setOpen] = React.useState(false);
 
   return (
-    <div className="flex items-center gap-1">
+    <div className={cn("flex items-center gap-1", className)} {...rest}>
       {variant === "navigation" && team && selectedProject && (
         <Link
           href={`/${team.slug}/${selectedProject.slug}`}
@@ -66,7 +64,6 @@ export default function ProjectSwitcher({
             className={cn(
               "justify-between",
               variant === "navigation" && "px-0",
-              className,
             )}
           >
             {variant === "select" &&

--- a/packages/web/components/team-switcher.tsx
+++ b/packages/web/components/team-switcher.tsx
@@ -20,17 +20,14 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
-type PopoverTriggerProps = React.ComponentPropsWithoutRef<
-  typeof PopoverTrigger
->;
-
-interface TeamSwitcherProps extends PopoverTriggerProps {
+type TeamSwitcherProps = {
   variant?: "navigation" | "select";
   selectedTeam?: schema.Team;
   teams?: schema.Team[];
   onTeamSelected?: (team: schema.Team) => void;
   onNewTeamSelected?: () => void;
-}
+  disabled?: boolean;
+} & React.HTMLAttributes<HTMLDivElement>;
 
 export default function TeamSwitcher({
   className,
@@ -40,6 +37,7 @@ export default function TeamSwitcher({
   onTeamSelected,
   onNewTeamSelected,
   disabled,
+  ...rest
 }: TeamSwitcherProps) {
   const [open, setOpen] = React.useState(false);
 
@@ -62,7 +60,7 @@ export default function TeamSwitcher({
   });
 
   return (
-    <div className="flex items-center gap-1">
+    <div className={cn("flex items-center gap-1", className)} {...rest}>
       {variant === "navigation" && selectedTeam && (
         <Link
           href={`/${selectedTeam.slug}`}
@@ -83,7 +81,6 @@ export default function TeamSwitcher({
               className={cn(
                 "justify-between",
                 variant === "navigation" && "px-0",
-                className,
               )}
             >
               {variant === "select" &&


### PR DESCRIPTION
For shared components, I'm realizing it's better to allow customization of the tailwind styles always on the outer most html element, and rely on te css cascase to influence child compoenent styles.

I use that approach here and then customize the switchers in the breadcrumb nav to look a bit better.