### PR TITLE
update sdk and sql parser to fix console

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5608,20 +5608,20 @@
       "link": true
     },
     "node_modules/@tableland/sdk": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-7.2.0.tgz",
-      "integrity": "sha512-WloTBEUm7txOi4Jmx1RlgYan2g4wolbhkgWwhLR37y/I1BKh2qd6X3N0g3YjYmyYvap1NdakeDgKc/i24gnrZg==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-7.2.1.tgz",
+      "integrity": "sha512-1dROnQcaEAwwHytkZDeyWeq0FHx9ehd1IXr9AhJRVLOWm90rbQCtxg+JtAkBD4fYF7kakUwRAlXnDBkSXxtwuQ==",
       "dependencies": {
         "@async-generators/from-emitter": "^0.3.0",
         "@tableland/evm": "^6.3.0",
-        "@tableland/sqlparser": "^1.3.0",
+        "@tableland/sqlparser": "^1.4.1",
         "ethers": "^6.12.1"
       }
     },
     "node_modules/@tableland/sqlparser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.3.0.tgz",
-      "integrity": "sha512-5DddKKbxa3q1DcUBcf+D9bF0xYjoqWYRs8t941vZWDMRQjuHNPW7JjRA0W8zH+LDeKYqWmyJFsm1se8RxTcJPA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.4.1.tgz",
+      "integrity": "sha512-j8VTruuNm6WA+EuUKTHK4w1zinmsf0P0w9vTD8x8EzrUaXpIQx8/+51Kw2CqgyOhwaKbXrMUTycJbeWfXW5U0A=="
     },
     "node_modules/@tableland/studio": {
       "resolved": "packages/web",
@@ -24655,7 +24655,7 @@
       "version": "0.0.3",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
-        "@tableland/sdk": "^7.2.0",
+        "@tableland/sdk": "^7.2.1",
         "@tableland/studio-chains": "^0.2.0",
         "@tableland/studio-mail": "^0.0.1",
         "@tableland/studio-store": "^0.0.3",
@@ -24681,8 +24681,8 @@
       "version": "0.3.0",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
-        "@tableland/sdk": "^7.2.0",
-        "@tableland/sqlparser": "^1.3.0",
+        "@tableland/sdk": "^7.2.1",
+        "@tableland/sqlparser": "^1.4.1",
         "@tableland/studio-client": "0.0.3",
         "@tableland/studio-validators": "^0.0.3",
         "chalk": "^5.3.0",
@@ -24779,7 +24779,7 @@
       "version": "0.0.3",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
-        "@tableland/sdk": "^7.2.0",
+        "@tableland/sdk": "^7.2.1",
         "drizzle-orm": "^0.29.3",
         "iron-session": "^8.0.1"
       }
@@ -24789,7 +24789,7 @@
       "version": "0.0.3",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
-        "@tableland/sdk": "^7.2.0",
+        "@tableland/sdk": "^7.2.1",
         "@tableland/studio-store": "^0.0.3",
         "zod": "^3.23.4"
       }
@@ -24816,7 +24816,7 @@
         "@radix-ui/react-toast": "^1.1.5",
         "@radix-ui/react-tooltip": "^1.0.7",
         "@tableland/nonce": "^1.0.1",
-        "@tableland/sdk": "^7.2.0",
+        "@tableland/sdk": "^7.2.1",
         "@tableland/studio-api": "^0.0.3",
         "@tableland/studio-chains": "^0.2.0",
         "@tableland/studio-client": "^0.0.3",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -21,7 +21,7 @@
   "author": "",
   "license": "MIT AND Apache-2.0",
   "dependencies": {
-    "@tableland/sdk": "^7.2.0",
+    "@tableland/sdk": "^7.2.1",
     "@tableland/studio-chains": "^0.2.0",
     "@tableland/studio-mail": "^0.0.1",
     "@tableland/studio-store": "^0.0.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,8 +44,8 @@
   },
   "license": "MIT AND Apache-2.0",
   "dependencies": {
-    "@tableland/sdk": "^7.2.0",
-    "@tableland/sqlparser": "^1.3.0",
+    "@tableland/sdk": "^7.2.1",
+    "@tableland/sqlparser": "^1.4.1",
     "@tableland/studio-client": "0.0.3",
     "@tableland/studio-validators": "^0.0.3",
     "chalk": "^5.3.0",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -21,7 +21,7 @@
   "author": "",
   "license": "MIT AND Apache-2.0",
   "dependencies": {
-    "@tableland/sdk": "^7.2.0",
+    "@tableland/sdk": "^7.2.1",
     "drizzle-orm": "^0.29.3",
     "iron-session": "^8.0.1"
   }

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/tablelandnetwork/studio#readme",
   "dependencies": {
-    "@tableland/sdk": "^7.2.0",
+    "@tableland/sdk": "^7.2.1",
     "@tableland/studio-store": "^0.0.3",
     "zod": "^3.23.4"
   }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -35,7 +35,7 @@
     "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@tableland/nonce": "^1.0.1",
-    "@tableland/sdk": "^7.2.0",
+    "@tableland/sdk": "^7.2.1",
     "@tableland/studio-api": "^0.0.3",
     "@tableland/studio-chains": "^0.2.0",
     "@tableland/studio-client": "^0.0.3",


### PR DESCRIPTION
This updates the sdk and sql parser so that definitions imported from tables that don't have prefixes work in the console.
Most specifically the Dimo project needs to work with the console.

I tested this in the vercel preview below.