### PR TITLE
(web) allow using global table names in console

### DIFF
--- a/packages/api/src/routers/projects.ts
+++ b/packages/api/src/routers/projects.ts
@@ -85,6 +85,7 @@ export function projectsRouter(store: Store) {
             ctx.orgId,
             input.name,
             input.description,
+            input.nativeMode,
             input.envNames.map((env) => env.name),
           );
           return project;
@@ -101,6 +102,7 @@ export function projectsRouter(store: Store) {
             input.projectId,
             input.name,
             input.description,
+            input.nativeMode,
           );
         } catch (err) {
           throw internalError("Error updating project", err);

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -127,6 +127,7 @@ export const builder = function (args: Yargs) {
             orgId,
             name,
             description,
+            nativeMode: false,
             // TODO: Allow user to specify env names
             envNames: [{ name: "default" }],
           });

--- a/packages/cli/test/sql/setup_studio_test_tables.sql
+++ b/packages/cli/test/sql/setup_studio_test_tables.sql
@@ -31,6 +31,7 @@ CREATE TABLE `projects` (
 	`name` text NOT NULL,
 	`slug` text NOT NULL,
 	`description` text NOT NULL,
+	`native_mode` integer,
 	`created_at` text,
 	`updated_at` text
 );

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -49,9 +49,11 @@ type API = ReturnType<typeof api>;
 // TODO: there is currently no concept of an environment for a user
 function studioAliases({
   environmentId,
+  nativeMode,
   apiUrl,
 }: {
   environmentId: string;
+  nativeMode?: boolean;
   apiUrl?: string;
 }): helpers.AliasesNameMap {
   const studioApi = api({
@@ -65,6 +67,9 @@ function studioAliases({
     _map = {};
     res.forEach(function (dep) {
       _map[dep.def.name] = dep.deployment.tableName;
+      if (nativeMode) {
+        _map[dep.deployment.tableName] = dep.deployment.tableName;
+      }
     });
   };
 

--- a/packages/store/src/api/projects.ts
+++ b/packages/store/src/api/projects.ts
@@ -43,6 +43,7 @@ export function initProjects(
       orgId: string,
       name: string,
       description: string,
+      nativeMode: boolean,
       envNames: string[],
     ) {
       const projectId = randomUUID();
@@ -53,6 +54,7 @@ export function initProjects(
         name,
         description,
         slug,
+        nativeMode: nativeMode ? 1 : 0,
         createdAt: now,
         updatedAt: now,
       };
@@ -88,6 +90,7 @@ export function initProjects(
       projectId: string,
       name?: string,
       description?: string,
+      nativeMode?: boolean,
     ) {
       const now = new Date().toISOString();
       const slug = name ? slugify(name) : undefined;
@@ -97,6 +100,7 @@ export function initProjects(
           name,
           slug,
           description,
+          nativeMode: nativeMode === undefined ? undefined : nativeMode ? 1 : 0,
           updatedAt: now,
         })
         .where(eq(projects.id, projectId))

--- a/packages/store/src/schema/index.ts
+++ b/packages/store/src/schema/index.ts
@@ -59,6 +59,7 @@ export const projects = sqliteTable("projects", {
   name: text("name").notNull(),
   slug: text("slug").notNull(),
   description: text("description").notNull(),
+  nativeMode: integer("native_mode"),
   createdAt: text("created_at"),
   updatedAt: text("updated_at"),
 });

--- a/packages/validators/src/validators/projects.ts
+++ b/packages/validators/src/validators/projects.ts
@@ -22,6 +22,7 @@ export const projectNameAvailableSchema = z.object({
 export const newProjectSchema = z.object({
   name: projectNameSchema,
   description: projectDescriptionSchema,
+  nativeMode: z.boolean(),
   envNames: z
     .array(envNameSchema)
     .min(1)
@@ -33,4 +34,5 @@ export const newProjectSchema = z.object({
 export const updateProjectSchema = z.object({
   name: projectNameSchema.optional(),
   description: projectDescriptionSchema.optional(),
+  nativeMode: z.boolean().optional(),
 });

--- a/packages/web/app/[org]/[project]/[env]/console/page.tsx
+++ b/packages/web/app/[org]/[project]/[env]/console/page.tsx
@@ -30,8 +30,9 @@ export default async function ConsolePage({
       <ConsoleTabs
         auth={session.auth}
         projectId={project.id}
+        nativeMode={!!project.nativeMode}
         environmentId={environment.id}
-        defs={deployments.map((d) => d.def)}
+        deployments={deployments}
       />
     </main>
   );

--- a/packages/web/app/[org]/[project]/_components/sidebar.tsx
+++ b/packages/web/app/[org]/[project]/_components/sidebar.tsx
@@ -184,6 +184,11 @@ export function Sidebar() {
               key={def.id}
               icon={Table2}
               title={def.name}
+              subtitle={
+                projectQuery.data.nativeMode && deployment
+                  ? deployment.tableName
+                  : undefined
+              }
               href={`/${orgQuery.data.slug}/${projectQuery.data.slug}/${linkEnv.slug}/${def.slug}`}
               selected={def.id === defQuery.data?.id}
               showIndicator={!!env && !deployment && !!isAuthorizedQuery.data}

--- a/packages/web/app/[org]/[project]/settings/_components/edit-project.tsx
+++ b/packages/web/app/[org]/[project]/settings/_components/edit-project.tsx
@@ -55,18 +55,18 @@ export default function EditProject({
     { retry: false },
   );
 
+  const utils = api.useUtils();
+
   const updateProject = api.projects.updateProject.useMutation({
     onSuccess: (project) => {
       router.replace(`/${org.slug}/${project.slug}/settings`);
       router.refresh();
+      void utils.projects.projectBySlug.invalidate({
+        slug: project.slug,
+        orgId: org.id,
+      });
     },
   });
-
-  api.projects.projectBySlug.useQuery(
-    updateProject.data
-      ? { slug: updateProject.data.slug, orgId: org.id }
-      : skipToken,
-  );
 
   const onSubmit = (values: z.infer<typeof updateProjectSchema>) => {
     updateProject.mutate({

--- a/packages/web/components/console.tsx
+++ b/packages/web/components/console.tsx
@@ -10,9 +10,9 @@ import { Database, type Result, helpers } from "@tableland/sdk";
 import CodeMirror from "@uiw/react-codemirror";
 import { SQLite, sql } from "@codemirror/lang-sql";
 import { vscodeDark } from "@uiw/codemirror-theme-vscode";
-import { type schema } from "@tableland/studio-store";
 import { Loader2 } from "lucide-react";
 import { getNetwork, switchNetwork } from "wagmi/actions";
+import { type RouterOutputs } from "@tableland/studio-api";
 import { DataTable } from "./data-table";
 import { Button } from "./ui/button";
 import { useToast } from "./ui/use-toast";
@@ -28,14 +28,16 @@ init().catch((err: any) => {
 
 export function Console({
   environmentId,
-  defs,
+  deployments,
+  nativeMode,
   query,
   setQuery,
   res,
   setRes,
 }: {
   environmentId: string;
-  defs: schema.Def[];
+  deployments: RouterOutputs["deployments"]["deploymentsByEnvironmentId"];
+  nativeMode: boolean;
   query: string;
   setQuery: (query: string) => void;
   res: Result<Record<string, unknown>> | undefined;
@@ -45,9 +47,21 @@ export function Console({
 
   const [pending, setPending] = useState(false);
 
-  const schema = defs.reduce<Record<string, string[]>>((acc, def) => {
-    return { ...acc, [def.name]: def.schema.columns.map((col) => col.name) };
-  }, {});
+  const schema = deployments.reduce<Record<string, string[]>>(
+    (acc, deployment) => {
+      const cols = deployment.def.schema.columns.map((col) => col.name);
+      const aliased = { [deployment.def.name]: cols };
+      const native = nativeMode
+        ? { [deployment.deployment.tableName]: cols }
+        : {};
+      return {
+        ...acc,
+        ...aliased,
+        ...native,
+      };
+    },
+    {},
+  );
 
   const columns: Array<ColumnDef<unknown>> = useMemo(
     () =>
@@ -91,6 +105,7 @@ export function Console({
     const aliases = studioAliases({
       environmentId,
       apiUrl: getBaseUrl(),
+      nativeMode,
     });
     const nameMapping = await aliases.read();
     const aliasMap = new Map(Object.entries(nameMapping));

--- a/packages/web/components/new-project-form.tsx
+++ b/packages/web/components/new-project-form.tsx
@@ -68,6 +68,7 @@ export default function NewProjectForm({
     defaultValues: {
       name: "",
       description: "",
+      nativeMode: false,
       envNames: [{ name: "default" }],
     },
   });

--- a/packages/web/components/sidebar-link.tsx
+++ b/packages/web/components/sidebar-link.tsx
@@ -4,12 +4,14 @@ import { Button } from "./ui/button";
 
 export default function SidebarLink({
   title,
+  subtitle,
   icon: Icon,
   href,
   selected,
   showIndicator = false,
 }: {
   title: string;
+  subtitle?: string;
   icon: LucideIcon;
   href: string;
   selected: boolean;
@@ -22,7 +24,19 @@ export default function SidebarLink({
         className="flex h-auto w-full justify-start gap-x-2 px-3 py-2 font-normal"
       >
         <Icon className="size-5 shrink-0" />
-        <div className="shrink truncate">{title}</div>
+        <div className="min-w-0 shrink text-left">
+          <div className="truncate" title={title}>
+            {title}
+          </div>
+          {subtitle && (
+            <div
+              className="truncate text-xs text-muted-foreground"
+              title={subtitle}
+            >
+              {subtitle}
+            </div>
+          )}
+        </div>
         {showIndicator && (
           <div className="ml-auto size-2 shrink-0 rounded-full bg-foreground" />
         )}

--- a/packages/web/drizzle/0003_noisy_slyde.sql
+++ b/packages/web/drizzle/0003_noisy_slyde.sql
@@ -1,0 +1,1 @@
+ALTER TABLE projects ADD `native_mode` integer;

--- a/packages/web/drizzle/meta/0003_snapshot.json
+++ b/packages/web/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,542 @@
+{
+  "version": "5",
+  "dialect": "sqlite",
+  "id": "cf087701-6b7b-4dc1-ac4e-7ad7951b05bb",
+  "prevId": "fcae76bd-9a52-4383-a6bb-a1c3f361a815",
+  "tables": {
+    "tables": {
+      "name": "tables",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "deployments": {
+      "name": "deployments",
+      "columns": {
+        "table_id": {
+          "name": "table_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "txn_hash": {
+          "name": "txn_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "deployments_table_id_environment_id_pk": {
+          "columns": [
+            "environment_id",
+            "table_id"
+          ],
+          "name": "deployments_table_id_environment_id_pk"
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "environments": {
+      "name": "environments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projectEnvIdx": {
+          "name": "projectEnvIdx",
+          "columns": [
+            "project_id",
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "project_tables": {
+      "name": "project_tables",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "table_id": {
+          "name": "table_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projectTablesIdx": {
+          "name": "projectTablesIdx",
+          "columns": [
+            "project_id",
+            "table_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "native_mode": {
+          "name": "native_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "team_invites": {
+      "name": "team_invites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sealed": {
+          "name": "sealed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inviter_team_id": {
+          "name": "inviter_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed_by_team_id": {
+          "name": "claimed_by_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "team_memberships": {
+      "name": "team_memberships",
+      "columns": {
+        "member_team_id": {
+          "name": "member_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_owner": {
+          "name": "is_owner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "memberTeamIdx": {
+          "name": "memberTeamIdx",
+          "columns": [
+            "member_team_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "team_projects": {
+      "name": "team_projects",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_owner": {
+          "name": "is_owner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "teamProjectIdx": {
+          "name": "teamProjectIdx",
+          "columns": [
+            "team_id",
+            "project_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "personal": {
+          "name": "personal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "nameIdx": {
+          "name": "nameIdx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "slugIdx": {
+          "name": "slugIdx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sealed": {
+          "name": "sealed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "teamIdIdx": {
+          "name": "teamIdIdx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1714180558700,
       "tag": "0002_certain_sage",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "5",
+      "when": 1723226766685,
+      "tag": "0003_noisy_slyde",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Dimo requested the ability to use both the alias table names and the global table names in the console.  This adds a toggle the allows the user to choose which option they would like to write queries in.

<img width="784" alt="Screen Shot 2024-07-24 at 1 17 54 PM" src="https://github.com/user-attachments/assets/a0d9af32-ac94-4001-8867-73e0d2403365">

![image](https://github.com/user-attachments/assets/378e6542-585a-4b1f-85a8-800bc63ae8ed)
