### PR TITLE
Migrate old personalTeam to personalOrg in session data

### DIFF
--- a/packages/api/src/session-data.ts
+++ b/packages/api/src/session-data.ts
@@ -12,6 +12,7 @@ export type SiweFields = Omit<
 export interface Auth {
   user: schema.User;
   personalOrg: schema.Org;
+  personalTeam?: schema.Org;
 }
 
 export interface SessionData {

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -8,7 +8,7 @@ import { type Store } from "@tableland/studio-store";
 import { TRPCError, initTRPC } from "@trpc/server";
 import superjson from "superjson";
 import { ZodError, z } from "zod";
-import { getIronSession } from "iron-session";
+import { type IronSession, getIronSession } from "iron-session";
 import { type SessionData, sessionOptions } from "./session-data";
 
 // TODO: the types and interfaces below are from iron-session, but they aren't exported.
@@ -88,17 +88,26 @@ export const getSession = async function ({
   req,
   res,
 }: GetSessionArgs) {
+  let session: IronSession<SessionData> | undefined;
   if (typeof cookies !== "undefined") {
-    return await getIronSession<SessionData>(cookies, sessionOptions);
+    session = await getIronSession<SessionData>(cookies, sessionOptions);
   }
-
   if (typeof req !== "undefined" && typeof res !== "undefined") {
-    return await getIronSession<SessionData>(req, res, sessionOptions);
+    session = await getIronSession<SessionData>(req, res, sessionOptions);
+  }
+  if (!session) {
+    throw new Error(
+      "cannot get session from context must supply cookies or req and res",
+    );
   }
 
-  throw new Error(
-    "cannot get session from context must supply cookies or req and res",
-  );
+  if (session.auth?.personalTeam) {
+    session.auth.personalOrg = session.auth.personalTeam;
+    session.auth.personalTeam = undefined;
+    await session.save();
+  }
+
+  return session;
 };
 
 // get a header from either of the accepted header types


### PR DESCRIPTION
I realized that already logged in sessions (from before #305 was merged) will have their org data saved under the old key `personalTeam`. This change accounts for that and moves that information to the new key. We can delete this code after some time.